### PR TITLE
Wrap powf() to fix compatibility with pre-GLIB 2.27

### DIFF
--- a/heclib/Dss7/Internal/powf_wrap.c
+++ b/heclib/Dss7/Internal/powf_wrap.c
@@ -1,0 +1,42 @@
+/* only under gcc (Linux)*/
+#if defined(__GNUC__) && (__linux__)
+
+/* for glibc version */
+#include <features.h>
+
+ /* glibc redefined powf in 2.27, breaks compatibility with prior versions */
+#if defined(__GLIBC__) && (__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 27)
+
+/* 64 bit glibc powf was defined in 2.2.5 */
+#if __LP64__
+# define SYMVER "GLIBC_2.2.5"
+
+/* 32-bit glibc powf was defined in 2.0 */
+#else 
+# define SYMVER "GLIBC_2.0"
+
+/* endif Architecture check */
+#endif
+
+/* to replace the function with the old call */
+#define USE_OLD_SYM(F,V) __asm__(".symver " #F ", " #F "@" V)
+
+#include <math.h> /* powf call */
+
+/* force powf to be from earlier compatible glibc */
+USE_OLD_SYM(powf,SYMVER);
+
+/* wrap the function requires gcc -Wl,--wrap=powf when linking */
+float __wrap_powf( float base, float exponent ) {
+  /* call into the supported version of powf */
+  return powf(base, exponent);
+}
+
+/* endif GLIBC >= 2.27 */
+#endif
+
+/* so gets reloaded if necessary */
+#undef _FEATURES_H
+
+/* endif gcc & linux */
+#endif

--- a/heclib/heclib_c_v6v7/Makefile.Linux
+++ b/heclib/heclib_c_v6v7/Makefile.Linux
@@ -57,6 +57,8 @@ Output/ztsStoreIrreg6.o:../Dss6/C/ztsStoreIrreg6.c
 	$(CC) $(CFLAGS) ../Dss6/C/ztsStoreIrreg6.c -o Output/ztsStoreIrreg6.o
 Output/ztsStoreReg6.o:../Dss6/C/ztsStoreReg6.c
 	$(CC) $(CFLAGS) ../Dss6/C/ztsStoreReg6.c -o Output/ztsStoreReg6.o
+Output/powf_wrap.o:../Dss7/Internal/powf_wrap.c
+	$(CC) $(CFLAGS) ../Dss7/Internal/powf_wrap.c -o Output/powf_wrap.o
 Output/charInt.o:../Dss7/Internal/charInt.c
 	$(CC) $(CFLAGS) ../Dss7/Internal/charInt.c -o Output/charInt.o
 Output/charLong.o:../Dss7/Internal/charLong.c
@@ -869,6 +871,7 @@ Output/ztsRetrieveIrreg6.o\
 Output/ztsRetrieveReg6.o\
 Output/ztsStoreIrreg6.o\
 Output/ztsStoreReg6.o\
+Output/powf_wrap.o\
 Output/charInt.o\
 Output/charLong.o\
 Output/zbinNew.o\

--- a/heclib/javaHeclib/Makefile.Linux
+++ b/heclib/javaHeclib/Makefile.Linux
@@ -522,4 +522,4 @@ javaHeclib.a:$(OBJS)
 	$(AR) -r Output/javaHeclib.a Output/*.o
 
 libjavaHeclib.so:$(OBJS)
-	gcc -m64 -shared -o Output/libjavaHeclib.so  Output/*.o ../heclib_c_v6v7/Output/*.o ../heclib_f_v6v7/Output/*.o ../../nws_shef/Output/*.o  -Wl,-z,defs -lz -lrt -lgfortran -lm
+	gcc -m64 -shared -o Output/libjavaHeclib.so  Output/*.o ../heclib_c_v6v7/Output/*.o ../heclib_f_v6v7/Output/*.o ../../nws_shef/Output/*.o  -Wl,-z,defs,--wrap=powf -lz -lrt -lgfortran -lm


### PR DESCRIPTION
powf(), from math.h/libm.so.6, was changed in GLIB 2.27. Compiling against glib 2.27 or newer will result in incompatibilities with any system that has an older version of glib, such as CentOS/RHEL 7 (glib 2.17). This results in the library being unable to be loaded at runtime, with an Unsatisfied link error stating that `/lib64/libm.so.6: version `GLIBC_2.27' not found (required by <snip>/libjavaHeclib.so)`

Wrap the function, and call the glib 2.2.5 version of the function, which is present in glibc 2.2.5 and newer, restoring minimum compatibility back to 2.17 and newer versions.

Ubuntu 18.04 and CentOS 8 have glib 2.27 and 2.28 respectively, so this change fixes Ubuntu 16.04 and CentOS 7 when built on Ubuntu 18.04+ or CentOS 8+. Tested on a CentOS 7 system with the default glib 2.17.