### PR TITLE
Squeeze slowdown

### DIFF
--- a/heclib/heclib_c/src/Internal/zhash.c
+++ b/heclib/heclib_c/src/Internal/zhash.c
@@ -35,7 +35,7 @@
 *				long long *pathnameHash (output)
 *					a almost unique hash code that distinguishes the pathname from other
 *					pathnames with the same table hash.  This will always be a very large, almost unique
-*					almost unique number.  pathnameHash will not be zero.
+*					number.  pathnameHash will not be zero.
 *					pathnameHash is returned with any value  (-max Int) < *pathnameHash < max Int
 *
 *

--- a/heclib/heclib_c/src/Internal/znewFileSize.c
+++ b/heclib/heclib_c/src/Internal/znewFileSize.c
@@ -108,8 +108,8 @@ void znewFileSize(long long *ifltab, int maxExpectedPaths, int hashSize, int bin
 		 fileHeader[zdssFileKeys.kbinSize] = 200;
 	 }
 	 else if (maxExpectedPaths <= 10000) {
-		 fileHeader[zdssFileKeys.kmaxHash] = 4096;
-		 fileHeader[zdssFileKeys.kbinSize] = 100;
+		 fileHeader[zdssFileKeys.kmaxHash] = 8192;
+		 fileHeader[zdssFileKeys.kbinSize] = 200;
 	 }
 	 else if (maxExpectedPaths <= 50000) {
 		 fileHeader[zdssFileKeys.kmaxHash] = 8192;

--- a/test/Dss-C/TestDssC.c
+++ b/test/Dss-C/TestDssC.c
@@ -7,57 +7,7 @@
 
 
 int runTheTests();
-int ReadGrids(const char* file1);
 
-int TodaysTest() {
-
-	//PrintHashTable("C:\\tmp\\file1-7.dss");
-	const char* file1 = "C:\\Temp\\grid\\EF_Russian_Precip7.dss";
-	const char* file2 = "C:\\Temp\\grid\\EF_Russian_Precip7-squeeze.dss";
-	//PrintHashTable(file1);
-	zsqueeze(file2);
-	
-	ReadGrids(file1);
-	ReadGrids(file2);
-	//unlink(file1);
-	
-    }
-	int ReadGrids(const char* file1){
-	long long start_time = getCurrentTimeMillis();
-	long long ifltab1[250];
-	int status = zopen(ifltab1, file1);
-
-	zStructCatalog* catStruct = zstructCatalogNew();
-	status = zcatalog(ifltab1, (const char*)0, catStruct, 1);
-	if (status < 0) {
-		printf("Error during catalog.  Error code %d\n", status);
-		return status;
-	}
-	for (int i = 0; i < catStruct->numberPathnames; i++)
-	{
-		zStructRecordBasics* recordBasics = zstructRecordBasicsNew(catStruct->pathnameList[i]);
-		status = zgetRecordBasics(ifltab1, recordBasics);
-		//printf("[%d] \"%s\" %d\n", i, catStruct->pathnameList[i], recordBasics->recordType);
-		
-
-		if (recordBasics->recordType == 420)// grid
-		{
-			zStructSpatialGrid* grid =  zstructSpatialGridNew(catStruct->pathnameList[i]);
-			zspatialGridRetrieve(ifltab1, grid, 1);
-			if(i%100 == 0)
-			   printf(".");
-		}
-		zstructFree(recordBasics);
-		
-	}
-	double elapsed = (getCurrentTimeMillis() - start_time) / 1000.0;
-
-	printf("\nSeconds elapsed: %f", elapsed);
-
-	zstructFree(catStruct);
-	zclose(ifltab1);
-	return status;
-}
 
 
 void usage(char* exeName)

--- a/test/Dss-C/TestDssC.c
+++ b/test/Dss-C/TestDssC.c
@@ -7,6 +7,57 @@
 
 
 int runTheTests();
+void ReadGrids(const char* file1);
+
+int TodaysTest() {
+
+	//PrintHashTable("C:\\tmp\\file1-7.dss");
+	const char* file1 = "C:\\Temp\\grid\\EF_Russian_Precip7.dss";
+	const char* file2 = "C:\\Temp\\grid\\EF_Russian_Precip7-squeeze.dss";
+	//PrintHashTable(file1);
+	zsqueeze(file2);
+	
+	ReadGrids(file1);
+	ReadGrids(file2);
+	//unlink(file1);
+	
+    }
+	void ReadGrids(const char* file1){
+	long long start_time = getCurrentTimeMillis();
+	long long ifltab1[250];
+	int status = zopen(ifltab1, file1);
+
+	zStructCatalog* catStruct = zstructCatalogNew();
+	status = zcatalog(ifltab1, (const char*)0, catStruct, 1);
+	if (status < 0) {
+		printf("Error during catalog.  Error code %d\n", status);
+		return status;
+	}
+	for (int i = 0; i < catStruct->numberPathnames; i++)
+	{
+		zStructRecordBasics* recordBasics = zstructRecordBasicsNew(catStruct->pathnameList[i]);
+		status = zgetRecordBasics(ifltab1, recordBasics);
+		//printf("[%d] \"%s\" %d\n", i, catStruct->pathnameList[i], recordBasics->recordType);
+		
+
+		if (recordBasics->recordType == 420)// grid
+		{
+			zStructSpatialGrid* grid =  zstructSpatialGridNew(catStruct->pathnameList[i]);
+			zspatialGridRetrieve(ifltab1, grid, 1);
+			if(i%100 == 0)
+			   printf(".");
+		}
+		zstructFree(recordBasics);
+		
+	}
+	double elapsed = (getCurrentTimeMillis() - start_time) / 1000.0;
+
+	printf("\nSeconds elapsed: %f", elapsed);
+
+	zstructFree(catStruct);
+	zclose(ifltab1);
+	return status;
+}
 
 
 void usage(char* exeName)
@@ -51,6 +102,7 @@ void usage(char* exeName)
 
 int main(int argc, char* argv[])
 {
+	
 	int status = 0;
 	long long start_time = getCurrentTimeMillis();
 

--- a/test/Dss-C/TestDssC.c
+++ b/test/Dss-C/TestDssC.c
@@ -7,7 +7,7 @@
 
 
 int runTheTests();
-void ReadGrids(const char* file1);
+int ReadGrids(const char* file1);
 
 int TodaysTest() {
 
@@ -22,7 +22,7 @@ int TodaysTest() {
 	//unlink(file1);
 	
     }
-	void ReadGrids(const char* file1){
+	int ReadGrids(const char* file1){
 	long long start_time = getCurrentTimeMillis();
 	long long ifltab1[250];
 	int status = zopen(ifltab1, file1);

--- a/test/Dss-C/TestDssC.h
+++ b/test/Dss-C/TestDssC.h
@@ -95,6 +95,6 @@ int CheckFile(char* dssFileName);
 void usage(char* exeName);
 int Export(char* dssFileName, char* path, int metaDataOnly);
 int PathnameTesting(char* dssFileName, int dssVersion);
-
+int PrintHashTable(const char* dssFilename);
 
 #endif

--- a/test/Dss-C/source/TestUtility.c
+++ b/test/Dss-C/source/TestUtility.c
@@ -28,7 +28,36 @@ int CheckPathnames(char* dssFileName)
 	return status;
 }
 
+int PrintHashTable(const char* dssFilename) {
+	long long ifltab[250];
+	long long tableHash=-1;
+	long long binAddress;
+	int status = zopen(ifltab, dssFilename);
+	if (status < 0) {
+		printf("Error opening file.  status = %d\n", status);
+		return status;
+	}
+	long long* fileHeader = (long long*)ifltab[zdssKeys.kfileHeader];
+	printf("\n Hash Table:  fileHeader[zdssFileKeys.kmaxHash] = %lld", (long long)fileHeader[zdssFileKeys.kmaxHash]);
+	printf("\n hash    bin-address");
+	printf("\n-------------------");
 
+	while (1) {
+		//  Need to read next hash from the hash table
+		// and then pathname bin
+		tableHash++;
+		if (tableHash == fileHeader[zdssFileKeys.kmaxHash]) {
+			//  All done - no more pathnames in file
+			break;
+		}
+
+		ifltab[zdssKeys.kaddTableHash] = tableHash + fileHeader[zdssFileKeys.kaddHashTableStart];
+		status = zget(ifltab, ifltab[zdssKeys.kaddTableHash], (int*)&binAddress, 1, 2);
+		printf("\n %5lld %lld",tableHash, binAddress);
+	}
+
+
+}
 
 int CheckFile(char* dssFileName)
 {

--- a/test/Dss-C/source/TestUtility.c
+++ b/test/Dss-C/source/TestUtility.c
@@ -419,3 +419,39 @@ int Export(char* dssFileName, char* path, int metaDataOnly)
 	return 0;
 }
 
+int ReadGrids(const char* file1){
+	long long start_time = getCurrentTimeMillis();
+	long long ifltab1[250];
+	int status = zopen(ifltab1, file1);
+
+	zStructCatalog* catStruct = zstructCatalogNew();
+	status = zcatalog(ifltab1, (const char*)0, catStruct, 1);
+	if (status < 0) {
+		printf("Error during catalog.  Error code %d\n", status);
+		return status;
+	}
+	for (int i = 0; i < catStruct->numberPathnames; i++)
+	{
+		zStructRecordBasics* recordBasics = zstructRecordBasicsNew(catStruct->pathnameList[i]);
+		status = zgetRecordBasics(ifltab1, recordBasics);
+		//printf("[%d] \"%s\" %d\n", i, catStruct->pathnameList[i], recordBasics->recordType);
+		
+
+		if (recordBasics->recordType == 420)// grid
+		{
+			zStructSpatialGrid* grid =  zstructSpatialGridNew(catStruct->pathnameList[i]);
+			zspatialGridRetrieve(ifltab1, grid, 1);
+			if(i%100 == 0)
+			   printf(".");
+		}
+		zstructFree(recordBasics);
+		
+	}
+	double elapsed = (getCurrentTimeMillis() - start_time) / 1000.0;
+
+	printf("\nSeconds elapsed: %f", elapsed);
+
+	zstructFree(catStruct);
+	zclose(ifltab1);
+	return status;
+}


### PR DESCRIPTION
increasing kmaxHash for files with maxExpectedPaths in range (1,10,000)
This improves reading speed by 10x when reading a file with 8760 paths. This is more consistent with other default file hash sizes.