### PR TITLE
Create full Archive.

### DIFF
--- a/heclib/Makefile
+++ b/heclib/Makefile
@@ -17,7 +17,7 @@ all:
 	(cd heclib_f; $(MAKE) )		
 	(mkdir -p Output)
 	( rm -f Output/heclib.a)
-	($(AR) -rcT Output/heclib.a ./heclib_c/Output/libhec_c.a ./heclib_f/Output/libhec_f.a )  
+	($(AR) -rc Output/heclib.a ./heclib_c/Output/libhec_c.a ./heclib_f/Output/libhec_f.a )  
 	(cd javaHeclib; $(MAKE) )
 
 	ls -la ./javaHeclib/Output/*javaHeclib.*


### PR DESCRIPTION
Build was created as a thin archive. This caused downstream builds to
fail as the code and function names were not present. only links to the
compiled object files.