### PR TITLE
limit units to 8 characters

### DIFF
--- a/heclib/heclib_f/src/zsitsi6.f
+++ b/heclib/heclib_f/src/zsitsi6.f
@@ -397,8 +397,7 @@ C
           end if
         end if
       end if
-      cunits = cunits(:len_trim(cunits))
-C      cunits = cunits(:8)
+      cunits = cunits(:min(len_trim(cunits),8))
 C
 C
 C     Get starting date of first block

--- a/heclib/heclib_f/src/zsrtsi6.f
+++ b/heclib/heclib_f/src/zsrtsi6.f
@@ -380,8 +380,7 @@ C
           end if
         end if
       end if
-      cunits = cunits(:len_trim(cunits))
-C      cunits = cunits(:8)
+      cunits = cunits(:min(len_trim(cunits),8))
 C
 C     Get time window
       CALL DATJUL ( CDATE, JULS, IERR)


### PR DESCRIPTION
units is stored as two 4-byte integers on disk