### PR TITLE
update path length (NPATH)

### DIFF
--- a/heclib/heclib_f/src/zsrtsi6.f
+++ b/heclib/heclib_f/src/zsrtsi6.f
@@ -1138,6 +1138,7 @@ C
       GO TO 990
 C
  987  CONTINUE
+      CALL CHRLNB (CPATH, NPATH)
       IF (MLEVEL.GE.1) WRITE (MUNIT, 988) CPATH(1:NPATH)
  988  FORMAT (' -----DSS---zsrtsx6:  ERROR;  File has Read Access Only',
      * /,' Pathname: ',A)


### PR DESCRIPTION
path: //RESERVOIR-1/ELEVATION//15MIN/RUN:ENGLISH EAO INITIAL ELEVATION/

```Stack trace terminated abnormally.
forrtl: severe (408): fort: (12): Variable CPATH has substring ending point 65 which is greater than the variable length of 60
