### PR TITLE
fix java crashes in JNI methods

### DIFF
--- a/heclib/heclib_c/src/headers/hecdssInternal.h
+++ b/heclib/heclib_c/src/headers/hecdssInternal.h
@@ -37,7 +37,7 @@
 
 
 #define DSS_VERSION "7-IO"
-#define DSS_VERSION_DATE "06 Jun 2022"
+#define DSS_VERSION_DATE "24 June 2022"
 
 
 const char *ztypeName(int recordType, int boolAbbreviation);

--- a/heclib/javaHeclib/src/Hec_zinquire.c
+++ b/heclib/javaHeclib/src/Hec_zinquire.c
@@ -21,6 +21,9 @@ JNIEXPORT jlong JNICALL Java_hec_heclib_util_Heclib_Hec_1zinquire
     const char *param;   
 	long long answer;
 
+	if (!j_ifltab) return -1;
+	if (!j_param) return -1;
+	
 	param = (*env)->GetStringUTFChars(env, j_param, 0);
 
     ifltab = (*env)->GetIntArrayElements(env, j_ifltab, 0);

--- a/heclib/javaHeclib/src/Hec_zlastWriteTime.c
+++ b/heclib/javaHeclib/src/Hec_zlastWriteTime.c
@@ -16,6 +16,8 @@ JNIEXPORT jlong JNICALL Java_hec_heclib_util_Heclib_Hec_1zlastWriteTime(
     long long longTime;
 	int *ifltab;
 
+	if (!j_ifltab) return - 1;
+
 	jint capacity=40;
 	(*env)->EnsureLocalCapacity(env, capacity);
 

--- a/heclib/javaHeclib/src/Hec_zlastWriteTimeFile.c
+++ b/heclib/javaHeclib/src/Hec_zlastWriteTimeFile.c
@@ -15,6 +15,8 @@ JNIEXPORT jlong JNICALL Java_hec_heclib_util_Heclib_Hec_1zlastWriteTimeFile(
 	int *ifltab;
 
 	jint capacity=40;
+	if (!j_ifltab) return -1;
+
 	(*env)->EnsureLocalCapacity(env, capacity);
 
 	ifltab		= (*env)->GetIntArrayElements(env, j_ifltab, 0);	


### PR DESCRIPTION
Some JNI functions were crashing the JVM, when called with null input data.
Update DSS_VERSION_DATE