### PR TITLE
Prevent userHeaderToString() from returning NULL

### DIFF
--- a/heclib/heclib_c/src/Utilities/verticalDatum.c
+++ b/heclib/heclib_c/src/Utilities/verticalDatum.c
@@ -315,6 +315,10 @@ char *userHeaderToString(const int *userHeader, const int userHeaderNumber) {
 		}
         free(buf);
     }
+    if (str == NULL) {
+        str = _malloc(1);
+        str[0] = '\0';
+    }
     return str;
 }
 

--- a/heclib/heclib_c/src/headers/hecdssInternal.h
+++ b/heclib/heclib_c/src/headers/hecdssInternal.h
@@ -37,7 +37,7 @@
 
 
 #define DSS_VERSION "7-IP"
-#define DSS_VERSION_DATE "7 July 2022"
+#define DSS_VERSION_DATE "27 July 2022"
 
 
 const char *ztypeName(int recordType, int boolAbbreviation);


### PR DESCRIPTION
I modified userHeaderToString() but didn't update the library version.