### PR TITLE
fix fortran forrtl error(63)

### DIFF
--- a/heclib/heclib_c/src/headers/hecdssInternal.h
+++ b/heclib/heclib_c/src/headers/hecdssInternal.h
@@ -37,7 +37,7 @@
 
 
 #define DSS_VERSION "7-IP"
-#define DSS_VERSION_DATE "18 August 2022"
+#define DSS_VERSION_DATE "23 August 2022"
 
 
 const char *ztypeName(int recordType, int boolAbbreviation);

--- a/heclib/heclib_f/src/zsitsi6.f
+++ b/heclib/heclib_f/src/zsitsi6.f
@@ -112,7 +112,7 @@ C
      */,T5,'Ending date and time:   ',3X,2I8,2X,A,
      */,T5,'Pathname: ',A)
       WRITE (MUNIT,30) KLBUFF,NVALS,INFLAG
- 30   FORMAT(T5,'BUFF DIM:',I5,'  NUMBER OF DATA:',I6,',  INFLAG:',I4)
+ 30   FORMAT(T5,'BUFF DIM:',I6,'  NUMBER OF DATA:',I6,',  INFLAG:',I4)
       J = NVALS
       IF (J.GT.25) J = 25
       DO 40 I=1,J


### PR DESCRIPTION
This PR fixes an Fortran runtime error.  The format Statement was not wide enough. Only occurs when debug level >= 9
![image](https://user-images.githubusercontent.com/4818531/186262242-baec4528-46b7-4da2-b199-495cc782c121.png)
