### PR TITLE
Update stringCat.c for macOS

### DIFF
--- a/heclib/heclib_c/src/Utilities/stringCat.c
+++ b/heclib/heclib_c/src/Utilities/stringCat.c
@@ -47,6 +47,9 @@ int stringCat (char *destination, size_t sizeOfDestination, const char* source, 
 		} 
 	}
 	return strncat_s(destination, sizeOfDestination, source, lenSource);
+#elif __APPLE__
+    strlcat(destination, source, sizeOfDestination);
+    return 0;
 #else
 		if( remainingSpace >0)
 		{   


### PR DESCRIPTION
Use macOS built-in [strlcat](https://developer.apple.com/documentation/kernel/1579344-strlcat) function for String Concatenation. The function includes security checks (including buffer overflow).

