### PR TITLE
use Format 'I0' to prevent Fortran runtime error

### DIFF
--- a/heclib/heclib_c/src/headers/hecdssInternal.h
+++ b/heclib/heclib_c/src/headers/hecdssInternal.h
@@ -37,7 +37,7 @@
 
 
 #define DSS_VERSION "7-IQ"
-#define DSS_VERSION_DATE "13 October 2022"
+#define DSS_VERSION_DATE "7 November 2022"
 
 
 const char *ztypeName(int recordType, int boolAbbreviation);

--- a/heclib/heclib_f/src/zbdump6.f
+++ b/heclib/heclib_f/src/zbdump6.f
@@ -18,7 +18,7 @@ C
       IF (MLEVEL.GE.11) WRITE (MUNIT,20) IFLTAB(KUNIT),
      * IFLTAB(KHANDL), IBGBUF, IFLTAB(KMXREC)
  20   FORMAT (T5,'-----DSS---zbdump6:  Dump Buffers for unit:',I5,
-     * ',  Handle:',I4,/,T10,'Min Buffer:',I4,',  Max Record:',I6)
+     * ',  Handle:',I4,/,T10,'Min Buffer:',I4,',  Max Record:',I0)
       IF (MLEVEL.GE.12) THEN
       WRITE (MUNIT,21) JCREC
       WRITE (MUNIT,22) JBUNIT


### PR DESCRIPTION
This fix improved the loading speed of a DSS file in the CAVI from 10 minutes to 15 seconds.