### PR TITLE
dotnet:make static and cleanup TimeSeries.IsRegular(...)

### DIFF
--- a/dotnet/DotNetTests/TimeSeriesTest.cs
+++ b/dotnet/DotNetTests/TimeSeriesTest.cs
@@ -508,6 +508,8 @@ namespace DSSUnitTests
       //ts.WriteToConsole();
       int idx = ts.IndexOf(t);
       Assert.IsTrue(idx >= 0);
+      Assert.IsTrue(ts.IsRegular());
+      Assert.IsTrue(TimeSeries.IsRegular(ts.Times));
       Assert.AreEqual(60, ts.Values[idx], 0.001);
 
       Console.WriteLine(ts.Values.Length);
@@ -796,6 +798,19 @@ namespace DSSUnitTests
             Assert.AreEqual(expectedCountAfterTrim, s.Count,message);
 
      }
+
+    [TestMethod()]  
+     public void CheckIsRegularInterval()
+    {
+      DateTime t1 = new DateTime(2022, 1, 1);
+      DateTime t2 = new DateTime(2022, 1, 2);
+      DateTime t3 = new DateTime(2022, 1, 3);
+
+      bool reg = TimeSeries.IsRegular(new DateTime[] { t1, t2, t3 });
+      Assert.IsTrue(reg);
+      reg = TimeSeries.IsRegular(new DateTime[] { t1, t3, t2 });
+      Assert.IsFalse(reg);
+    }
 
     }
 }

--- a/dotnet/Hec.Dss/Hec.Dss.csproj.nuspec
+++ b/dotnet/Hec.Dss/Hec.Dss.csproj.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Hec.Dss</id>
-    <version>1.1.0.0</version>
+    <version>1.2.*</version>
     <authors>Hydrologic Engineering Center</authors>
     <owners>HEC</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/dotnet/Hec.Dss/PairedData.cs
+++ b/dotnet/Hec.Dss/PairedData.cs
@@ -17,8 +17,7 @@ namespace Hec.Dss
     public string TypeDependent { get; set; }
     public string UnitsIndependent { get; set; }
     public string UnitsDependent { get; set; }
-    public int YCount { get { return Values.Count; } }
-    public int XCount { get { return Values[0].Length; } }
+    public int CurveCount { get { return Values[0].Length; } }
 
     public LocationInformation LocationInformation { get; set; }
 
@@ -78,7 +77,7 @@ namespace Hec.Dss
       }
       
 
-      for (int i = 0; i < XCount; i++)
+      for (int i = 0; i < CurveCount; i++)
       {
         var row = new object[] { };
         if (includeIndex)

--- a/dotnet/Hec.Dss/TimeSeries.cs
+++ b/dotnet/Hec.Dss/TimeSeries.cs
@@ -104,23 +104,16 @@ namespace Hec.Dss
       return Path.IsRegular;
     }
 
-    public bool IsRegular(DateTime[] times)
+    public static bool IsRegular(DateTime[] times)
     {
-      var temp = times;
-      var td = temp[1] - temp[0];
-      for (int i = 0; i < temp.Length; i++)
+      if (times == null || times.Length < 2)
+        return false;
+
+      var diff = times[1] - times[0];
+      for (int i = 1; i < times.Length - 1; i++)
       {
-        if (i == 0)
-          continue;
-        else if (i == temp.Length - 1)
-          break;
-        else
-        {
-          if (temp[i + 1] - temp[i] == td) // check if time difference is the same throughout list
-            continue;
-          else
-            return false;
-        }
+        if (times[i + 1] - times[i] != diff) // check if time difference is the same throughout list
+          return false;
       }
       return true;
     }


### PR DESCRIPTION
PairedData naming changes
bump Hec.Dss.dll (dotnet) version 1.2
use automatic build and revision numbers.