### PR TITLE
remove -beta1 from version

### DIFF
--- a/dotnet/Hec.Dss/Hec.Dss.csproj.nuspec
+++ b/dotnet/Hec.Dss/Hec.Dss.csproj.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Hec.Dss</id>
-    <version>1.2.0-beta1</version>
+    <version>1.2.0</version>
     <authors>Hydrologic Engineering Center</authors>
     <owners>HEC</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
inside visual studio -beta1 version is not showing up, so  using  1.2.0 instead.