### PR TITLE
Bugfix/zcopy record vdi

### DIFF
--- a/heclib/heclib_c/src/DssInterface/v6and7/zcopyRecord.c
+++ b/heclib/heclib_c/src/DssInterface/v6and7/zcopyRecord.c
@@ -230,6 +230,19 @@ int zcopyRecord(long long *ifltabFrom, long long *ifltabTo, const char *pathname
 						zdssErrorSeverity.MEMORY_ERROR,
 						pathnameTo, "Allocating ts location pathname");
 				}
+				if (versFileFrom == 7 && versFileTo == 6) {
+					// copy any VDI from location struct into user header
+					int* hdr = copyVdiFromLocationStructToUserHeader(tss->locationStruct, tss->userHeader, &tss->userHeaderNumber, &status);
+					if (status != STATUS_OKAY) {
+						zstructFree(tss);
+						return zerrorProcessing(ifltabFrom, DSS_FUNCTION_zcopyRecord_ID,
+							zdssErrorCodes.CANNOT_ALLOCATE_MEMORY, 0, 0,
+							zdssErrorSeverity.MEMORY_ERROR,
+							pathnameTo, "Copying time series VDI to user header");
+					}
+					tss->userHeader = hdr;
+					tss->allocated[zSTRUCT_userHeader] = tss->userHeader != NULL;
+				}
 			}
 			status = ztsStore(ifltabTo, tss, 0);
 			zstructFree(tss);
@@ -271,6 +284,19 @@ int zcopyRecord(long long *ifltabFrom, long long *ifltabTo, const char *pathname
 						zdssErrorCodes.CANNOT_ALLOCATE_MEMORY, 0, 0,
 						zdssErrorSeverity.MEMORY_ERROR,
 						pathnameTo, "Allocating paired data location pathname");
+				}
+				if (versFileFrom == 7 && versFileTo == 6) {
+					// copy any VDI from location struct into user header
+					int* hdr = copyVdiFromLocationStructToUserHeader(pds->locationStruct, pds->userHeader, &pds->userHeaderNumber, &status);
+					if (status != STATUS_OKAY) {
+						zstructFree(tss);
+						return zerrorProcessing(ifltabFrom, DSS_FUNCTION_zcopyRecord_ID,
+							zdssErrorCodes.CANNOT_ALLOCATE_MEMORY, 0, 0,
+							zdssErrorSeverity.MEMORY_ERROR,
+							pathnameTo, "Copying paired data VDI to user header");
+					}
+					pds->userHeader = hdr;
+					pds->allocated[zSTRUCT_userHeader] = pds->userHeader != NULL;
 				}
 			}
 			status = zpdStore(ifltabTo, pds, 0);

--- a/heclib/heclib_c/src/DssInterface/v6and7/zcopyRecord.c
+++ b/heclib/heclib_c/src/DssInterface/v6and7/zcopyRecord.c
@@ -130,47 +130,14 @@ int zcopyRecord(long long *ifltabFrom, long long *ifltabTo, const char *pathname
 				//----------------------------------------------------------------------------//
 				// force standard copy if source and destination records are Elev time series //
 				//----------------------------------------------------------------------------//
-				char cPart[MAX_PART_SIZE];
-				zpathnameGetPart(pathnameFrom, 3, cPart, sizeof(cPart));
-				if (!strncasecmp(cPart, "ELEV", 4)) {
-					zpathnameGetPart(pathnameTo, 3, cPart, sizeof(cPart));
-					if (!strncasecmp(cPart, "ELEV", 4)) {
-						boolInternalCopy = 0; // zcopyRecordInternal doesn't copy VDI in location record
-					}
+				if (pathnameIsElevTs(pathnameFrom) && pathnameIsElevTs(pathnameTo)) {
+					boolInternalCopy = 0; // zcopyRecordInternal doesn't copy VDI in location record
 				}
 			}
 		}
 		else if ((dataType >= DATA_TYPE_PD) && (dataType < DATA_TYPE_TEXT)) {
-			//----------------------------------------------------------------------------//
-			// force standard copy if source and destination records are Elev paired data //
-			//----------------------------------------------------------------------------//
-			int indElev = FALSE;
-			int depElev = FALSE;
-			char cPart[MAX_PART_SIZE];
-			char* saveptr;
-			char* cp;
-			zpathnameGetPart(pathnameFrom, 3, cPart, sizeof(cPart));
-			cp = strtok_r(cPart, "-", &saveptr);
-			if (!strncasecmp(cp, "ELEV", 4)) {
-				indElev = TRUE;
-			}
-			cp = strtok_r(NULL, "-", &saveptr);
-			if (cp && !strncasecmp(cp, "ELEV", 4)) {
-				depElev = TRUE;
-			}
-			if (indElev || depElev) {
-				zpathnameGetPart(pathnameTo, 3, cPart, sizeof(cPart));
-				cp = strtok_r(cPart, "-", &saveptr);
-				if (!strncasecmp(cp, "ELEV", 4)) {
-					indElev = TRUE;
-				}
-				cp = strtok_r(NULL, "-", &saveptr);
-				if (cp && !strncasecmp(cp, "ELEV", 4)) {
-					depElev = TRUE;
-				}
-				if (indElev || depElev) {
-					boolInternalCopy = 0; // zcopyRecordInternal doesn't copy VDI in location record
-				}
+			if (pathnameIsElevPd(pathnameFrom) && pathnameIsElevPd(pathnameTo)) {
+				boolInternalCopy = 0; // zcopyRecordInternal doesn't copy VDI in location record
 			}
 		}
 	}

--- a/heclib/heclib_c/src/DssInterface/v6and7/zcopyRecord.c
+++ b/heclib/heclib_c/src/DssInterface/v6and7/zcopyRecord.c
@@ -4,6 +4,7 @@
 #include "heclib.h"
 #include "hecdssInternal.h"
 #include "zdssKeys.h"
+#include "verticalDatum.h"
 
 
 /**
@@ -125,6 +126,52 @@ int zcopyRecord(long long *ifltabFrom, long long *ifltabTo, const char *pathname
 					}
 				}
 			}
+			if (boolInternalCopy) {
+				//----------------------------------------------------------------------------//
+				// force standard copy if source and destination records are Elev time series //
+				//----------------------------------------------------------------------------//
+				char cPart[MAX_PART_SIZE];
+				zpathnameGetPart(pathnameFrom, 3, cPart, sizeof(cPart));
+				if (!strncasecmp(cPart, "ELEV", 4)) {
+					zpathnameGetPart(pathnameTo, 3, cPart, sizeof(cPart));
+					if (!strncasecmp(cPart, "ELEV", 4)) {
+						boolInternalCopy = 0; // zcopyRecordInternal doesn't copy VDI in location record
+					}
+				}
+			}
+		}
+		else if ((dataType >= DATA_TYPE_PD) && (dataType < DATA_TYPE_TEXT)) {
+			//----------------------------------------------------------------------------//
+			// force standard copy if source and destination records are Elev paired data //
+			//----------------------------------------------------------------------------//
+			int indElev = FALSE;
+			int depElev = FALSE;
+			char cPart[MAX_PART_SIZE];
+			char* saveptr;
+			char* cp;
+			zpathnameGetPart(pathnameFrom, 3, cPart, sizeof(cPart));
+			cp = strtok_r(cPart, "-", &saveptr);
+			if (!strncasecmp(cp, "ELEV", 4)) {
+				indElev = TRUE;
+			}
+			cp = strtok_r(NULL, "-", &saveptr);
+			if (cp && !strncasecmp(cp, "ELEV", 4)) {
+				depElev = TRUE;
+			}
+			if (indElev || depElev) {
+				zpathnameGetPart(pathnameTo, 3, cPart, sizeof(cPart));
+				cp = strtok_r(cPart, "-", &saveptr);
+				if (!strncasecmp(cp, "ELEV", 4)) {
+					indElev = TRUE;
+				}
+				cp = strtok_r(NULL, "-", &saveptr);
+				if (cp && !strncasecmp(cp, "ELEV", 4)) {
+					depElev = TRUE;
+				}
+				if (indElev || depElev) {
+					boolInternalCopy = 0; // zcopyRecordInternal doesn't copy VDI in location record
+				}
+			}
 		}
 	}
 	else {
@@ -171,6 +218,19 @@ int zcopyRecord(long long *ifltabFrom, long long *ifltabTo, const char *pathname
 				free(tss->timeWindow);
 				tss->timeWindow = 0;
 			}
+			if (tss->locationStruct) {
+				if (tss->locationStruct->pathname) {
+					free(tss->locationStruct->pathname);
+				}
+				tss->locationStruct->pathname = mallocAndCopyPath(pathnameTo);
+				if (!tss->pathname) {
+					zstructFree(tss);
+					return zerrorProcessing(ifltabFrom, DSS_FUNCTION_zcopyRecord_ID,
+						zdssErrorCodes.CANNOT_ALLOCATE_MEMORY, 0, 0,
+						zdssErrorSeverity.MEMORY_ERROR,
+						pathnameTo, "Allocating ts location pathname");
+				}
+			}
 			status = ztsStore(ifltabTo, tss, 0);
 			zstructFree(tss);
 			if (zisError(status)) {
@@ -199,6 +259,19 @@ int zcopyRecord(long long *ifltabFrom, long long *ifltabTo, const char *pathname
 										zdssErrorCodes.CANNOT_ALLOCATE_MEMORY, 0, 0,
 										zdssErrorSeverity.MEMORY_ERROR,
 										pathnameTo, "Allocating paired data pathname");
+			}
+			if (pds->locationStruct) {
+				if (pds->locationStruct->pathname) {
+					free(pds->locationStruct->pathname);
+				}
+				pds->locationStruct->pathname = mallocAndCopyPath(pathnameTo);
+				if (!pds->pathname) {
+					zstructFree(pds);
+					return zerrorProcessing(ifltabFrom, DSS_FUNCTION_zcopyRecord_ID,
+						zdssErrorCodes.CANNOT_ALLOCATE_MEMORY, 0, 0,
+						zdssErrorSeverity.MEMORY_ERROR,
+						pathnameTo, "Allocating paired data location pathname");
+				}
 			}
 			status = zpdStore(ifltabTo, pds, 0);
 			zstructFree(pds);

--- a/heclib/heclib_c/src/DssInterface/v6and7/zcopyRecord.c
+++ b/heclib/heclib_c/src/DssInterface/v6and7/zcopyRecord.c
@@ -230,19 +230,6 @@ int zcopyRecord(long long *ifltabFrom, long long *ifltabTo, const char *pathname
 						zdssErrorSeverity.MEMORY_ERROR,
 						pathnameTo, "Allocating ts location pathname");
 				}
-				if (versFileFrom == 7 && versFileTo == 6) {
-					// copy any VDI from location struct into user header
-					int* hdr = copyVdiFromLocationStructToUserHeader(tss->locationStruct, tss->userHeader, &tss->userHeaderNumber, &status);
-					if (status != STATUS_OKAY) {
-						zstructFree(tss);
-						return zerrorProcessing(ifltabFrom, DSS_FUNCTION_zcopyRecord_ID,
-							zdssErrorCodes.CANNOT_ALLOCATE_MEMORY, 0, 0,
-							zdssErrorSeverity.MEMORY_ERROR,
-							pathnameTo, "Copying time series VDI to user header");
-					}
-					tss->userHeader = hdr;
-					tss->allocated[zSTRUCT_userHeader] = tss->userHeader != NULL;
-				}
 			}
 			status = ztsStore(ifltabTo, tss, 0);
 			zstructFree(tss);
@@ -284,19 +271,6 @@ int zcopyRecord(long long *ifltabFrom, long long *ifltabTo, const char *pathname
 						zdssErrorCodes.CANNOT_ALLOCATE_MEMORY, 0, 0,
 						zdssErrorSeverity.MEMORY_ERROR,
 						pathnameTo, "Allocating paired data location pathname");
-				}
-				if (versFileFrom == 7 && versFileTo == 6) {
-					// copy any VDI from location struct into user header
-					int* hdr = copyVdiFromLocationStructToUserHeader(pds->locationStruct, pds->userHeader, &pds->userHeaderNumber, &status);
-					if (status != STATUS_OKAY) {
-						zstructFree(tss);
-						return zerrorProcessing(ifltabFrom, DSS_FUNCTION_zcopyRecord_ID,
-							zdssErrorCodes.CANNOT_ALLOCATE_MEMORY, 0, 0,
-							zdssErrorSeverity.MEMORY_ERROR,
-							pathnameTo, "Copying paired data VDI to user header");
-					}
-					pds->userHeader = hdr;
-					pds->allocated[zSTRUCT_userHeader] = pds->userHeader != NULL;
 				}
 			}
 			status = zpdStore(ifltabTo, pds, 0);

--- a/heclib/heclib_c/src/Public/zpdRetrieve.c
+++ b/heclib/heclib_c/src/Public/zpdRetrieve.c
@@ -707,24 +707,16 @@ int zpdRetrieve(long long *ifltab, zStructPairedData *pds, int retrieveSizeFlag)
 
 		int indElev = FALSE;
 		int depElev = FALSE;
-		char cPart[65];
-		char *saveptr;
 		char cvertical_datum[CVERTICAL_DATUM_SIZE];
 		int  ivertical_datum = IVERTICAL_DATUM_UNSET;
 		int  ivertical_datum2;
 		verticalDatumInfo _vdi;
 		verticalDatumInfo *vdi = NULL;
 		char errmsg[1024];
-		zpathnameGetPart(pds->pathname, 3, cPart, sizeof(cPart));
-		char *cp = strtok_r(cPart, "-", &saveptr);
-		if (!strncasecmp(cp, "ELEV", 4)) {
-			indElev = TRUE;
-		}
-		cp = strtok_r(NULL, "-", &saveptr);
-		if (cp && !strncasecmp(cp, "ELEV", 4)) {
-			depElev = TRUE;
-		}
-		if (indElev || depElev) {
+		int elevParam = pathnameIsElevPd(pds->pathname); // returns 0, 1, 2, or 3
+		indElev = elevParam % 2;
+		depElev = elevParam / 2;
+		if (elevParam) {
 			//------------------------//
 			// elevation in parameter //
 			//------------------------//

--- a/heclib/heclib_c/src/Public/zpdStore.c
+++ b/heclib/heclib_c/src/Public/zpdStore.c
@@ -328,18 +328,10 @@ int zpdStore(long long *ifltab, zStructPairedData *pds, int storageFlag)
 	double *origDoubleVals = NULL;
 	int indElev = FALSE;
 	int depElev = FALSE;
-	char cPart[65];
-	char *saveptr;
-	zpathnameGetPart(pds->pathname, 3, cPart, sizeof(cPart));
-	char *cp = strtok_r(cPart, "-", &saveptr);
-	if (!strncasecmp(cp, "ELEV", 4)) {
-		indElev = TRUE;
-	}
-	cp = strtok_r(NULL, "-", &saveptr);
-	if (cp && !strncasecmp(cp, "ELEV", 4)) {
-		depElev = TRUE;
-	}
-	if (indElev || depElev) {
+	int elevParam = pathnameIsElevPd(pds->pathname); // returns 0, 1, 2, or 3
+	indElev = elevParam % 2;
+	depElev = elevParam / 2;
+	if (elevParam) {
 		//-----------------------//
 		// get the current datum //
 		//-----------------------//

--- a/heclib/heclib_c/src/Public/zpdStore.c
+++ b/heclib/heclib_c/src/Public/zpdStore.c
@@ -305,7 +305,6 @@ int zpdStore(long long *ifltab, zStructPairedData *pds, int storageFlag)
 				pds->pathname, "Copying paired data VDI to user header");
 		}
 		pds->userHeader = hdr;
-		pds->allocated[zSTRUCT_userHeader] = pds->userHeader != NULL;
 		status = zpdStore6(ifltab, pds, storageFlag);
 		// restore the original user header
 		if (hdr != origHeader) {

--- a/heclib/heclib_c/src/Public/ztsRetrieve.c
+++ b/heclib/heclib_c/src/Public/ztsRetrieve.c
@@ -423,9 +423,7 @@ int ztsRetrieve(long long *ifltab, zStructTimeSeries *tss,
 		//--------------------------------------------------//
 		// convert to requested vertical datum if necessary //
 		//--------------------------------------------------//
-		char cPart[65];
-		zpathnameGetPart(tss->pathname, 3, cPart, sizeof(cPart));
-		if (!strncasecmp(cPart, "ELEV", 4)) {
+		if (pathnameIsElevTs(tss->pathname)) {
 			//------------------------//
 			// parameter is elevation //
 			//------------------------//

--- a/heclib/heclib_c/src/Public/ztsStore.c
+++ b/heclib/heclib_c/src/Public/ztsStore.c
@@ -402,13 +402,11 @@ int ztsStore(long long *ifltab, zStructTimeSeries *tss, int storageFlag)
 		float  *origFloatVals = NULL;
 		double *tmpDoubleVals = NULL;
 		double *origDoubleVals = NULL;
-		char cPart[MAX_PART_SIZE];
 		char startDate[10];
 		char startTime[5];
 		char endDate[10];
 		char endTime[5];
-		zpathnameGetPart(tss->pathname, 3, cPart, sizeof(cPart));
-		if (!strncasecmp(cPart, "ELEV", 4) && (tss->floatValues || tss->doubleValues)) {
+		if (pathnameIsElevTs(tss->pathname) && (tss->floatValues || tss->doubleValues)) {
 			//-----------------------//
 			// get the current datum //
 			//-----------------------//

--- a/heclib/heclib_c/src/Public/ztsStore.c
+++ b/heclib/heclib_c/src/Public/ztsStore.c
@@ -357,7 +357,6 @@ int ztsStore(long long *ifltab, zStructTimeSeries *tss, int storageFlag)
 				tss->pathname, "Copying time series VDI to user header");
 		}
 		tss->userHeader = hdr;
-		tss->allocated[zSTRUCT_userHeader] = tss->userHeader != NULL;
 		if (intervalType == 0) {
 			status = ztsStoreReg6(ifltab, tss, storageFlag);
 		}

--- a/heclib/heclib_c/src/Public/ztsStore.c
+++ b/heclib/heclib_c/src/Public/ztsStore.c
@@ -345,11 +345,30 @@ int ztsStore(long long *ifltab, zStructTimeSeries *tss, int storageFlag)
 				0, zdssErrorSeverity.WARNING, tss->pathname,
 				"Profiles are not implemented in version 6");
 		}
+		// copy any VDI from location struct into user header
+		int* origHeader = tss->userHeader;
+		int origHeaderNumber = tss->userHeaderNumber;
+		int* hdr = copyVdiFromLocationStructToUserHeader(tss->locationStruct, tss->userHeader, &tss->userHeaderNumber, FALSE, &status);
+		if (status != STATUS_OKAY) {
+			zstructFree(tss);
+			return zerrorProcessing(ifltab, DSS_FUNCTION_ztsStore_ID,
+				zdssErrorCodes.CANNOT_ALLOCATE_MEMORY, 0, 0,
+				zdssErrorSeverity.MEMORY_ERROR,
+				tss->pathname, "Copying time series VDI to user header");
+		}
+		tss->userHeader = hdr;
+		tss->allocated[zSTRUCT_userHeader] = tss->userHeader != NULL;
 		if (intervalType == 0) {
 			status = ztsStoreReg6(ifltab, tss, storageFlag);
 		}
 		else {
 			status = ztsStoreIrreg6(ifltab, tss, storageFlag);
+		}
+		// restore the original user header
+		if (hdr != origHeader) {
+			tss->userHeader = origHeader;
+			tss->userHeaderNumber = origHeaderNumber;
+			free(hdr);
 		}
 	}
 	else {

--- a/heclib/heclib_c/src/Utilities/verticalDatum.c
+++ b/heclib/heclib_c/src/Utilities/verticalDatum.c
@@ -1915,7 +1915,7 @@ int* copyVdiFromLocationStructToUserHeader(
                     headerBuf == malloc(len);
                     if (headerBuf == NULL) {
                         free(compressed);
-                        status = -1;
+                        *status = -1;
                         break;
                     }
                 }
@@ -1929,14 +1929,14 @@ int* copyVdiFromLocationStructToUserHeader(
                     if (cp == NULL) {
                         free(compressed);
                         free(headerBuf);
-                        status = -2;
+                        *status = -2;
                         break;
                     }
                     headerBuf = cp;
                     if (insertIntoDelimitedString(&headerBuf, len, VERTICAL_DATUM_INFO_USER_HEADER_PARAM, compressed, ":", FALSE, ';')) {
                         // unexpected error
                         free(compressed);
-                        status = -3;
+                        *status = -3;
                         return userHeader;
                     }
                 }

--- a/heclib/heclib_c/src/Utilities/verticalDatum.c
+++ b/heclib/heclib_c/src/Utilities/verticalDatum.c
@@ -1860,8 +1860,8 @@ char* processStorageVdis(
         else {
             targetVdi = &fileVdi;
         }
-        if (!strcmp(currentDatum, CVERTICAL_DATUM_UNSET)         // current datum == UNSET
-            || !strcmp(currentDatum, targetVdi->nativeDatum)) {  // || current datum == native datum
+        if (!strcmp(currentDatum, CVERTICAL_DATUM_UNSET)      // current datum == UNSET
+         || !strcmp(currentDatum, targetVdi->nativeDatum)) {  // || current datum == native datum
             *offsetToUse = 0;
         }
         else if (!strcmp(currentDatum, CVERTICAL_DATUM_NAVD88)) {
@@ -1896,7 +1896,9 @@ char* processStorageVdis(
     }
     return NULL;
 }
-
+//
+// See verticalDatum.h for documentation
+//
 int* copyVdiFromLocationStructToUserHeader(
     zStructLocation* locStruct,
     int* userHeader,
@@ -1951,4 +1953,60 @@ int* copyVdiFromLocationStructToUserHeader(
         }
     }
     return userHeader;
+}
+//
+// See verticalDatum.h for documentation
+//
+int pathnameIsElevTs(const char* pathname) {
+    int isElevTs = FALSE;
+    if (pathname != NULL) {
+        char cPart[MAX_PART_SIZE];
+        zpathnameGetPart(pathname, 3, cPart, sizeof(cPart));
+        isElevTs = !strncasecmp(cPart, "ELEV", 4);
+    }
+    return isElevTs;
+}
+void pathnameiselevts_(const char* pathname, int* result, size_t pathnameLen) {
+    char* cPathname = mallocAndInit(pathnameLen + 1);
+    F2C(pathname, cPathname, pathnameLen, pathnameLen + 1);
+    *result = pathnameIsElevTs(cPathname);
+    free(cPathname);
+}
+//
+// See verticalDatum.h for documentation
+//
+int pathnameIsElevPd(const char* pathname) {
+    int result = 0;
+    if (pathname != NULL) {
+        char cPart[MAX_PART_SIZE];
+        zpathnameGetPart(pathname, 3, cPart, sizeof(cPart));
+        char* saveptr;
+        char* cp = strtok_r(cPart, "-", &saveptr);
+        if (!strncasecmp(cp, "ELEV", 4)) {
+            result += 1;
+        }
+        cp = strtok_r(NULL, "-", &saveptr);
+        if (!strncasecmp(cp, "ELEV", 4)) {
+            result += 2;
+        }
+    }
+    return result;
+}
+void pathnameiselevpd_(const char* pathname, int* result, size_t pathnameLen) {
+    char* cPathname = mallocAndInit(pathnameLen + 1);
+    F2C(pathname, cPathname, pathnameLen, pathnameLen + 1);
+    *result = pathnameIsElevPd(cPathname);
+    free(cPathname);
+}
+//
+// See verticalDatum.h for documentation
+//
+int pathnameIsElevTsOrPd(const char* pathname) {
+    return pathnameIsElevTs(pathname) || pathnameIsElevPd(pathname);
+}
+void pathnameiselevtsorpd_(const char* pathname, int* result, size_t pathnameLen) {
+    char* cPathname = mallocAndInit(pathnameLen + 1);
+    F2C(pathname, cPathname, pathnameLen, pathnameLen + 1);
+    *result = pathnameIsElevTsOrPd(cPathname);
+    free(cPathname);
 }

--- a/heclib/heclib_c/src/Utilities/verticalDatum.c
+++ b/heclib/heclib_c/src/Utilities/verticalDatum.c
@@ -1903,7 +1903,7 @@ int* copyVdiFromLocationStructToUserHeader(
     zStructLocation* locStruct,
     int* userHeader,
     int* userHeaderNumber,
-    int freeOriginalHeader,
+    const int freeOriginalHeader,
     int* status) {
 
     *status = 0;

--- a/heclib/heclib_c/src/Utilities/verticalDatum.c
+++ b/heclib/heclib_c/src/Utilities/verticalDatum.c
@@ -1901,10 +1901,11 @@ int* copyVdiFromLocationStructToUserHeader(
     zStructLocation* locStruct,
     int* userHeader,
     int* userHeaderNumber,
+    int freeOriginalHeader,
     int* status) {
 
+    *status = 0;
     if (locStruct->supplemental) {
-        *status = 0;
         char* compressed = extractFromDelimitedString(&locStruct->supplemental, VERTICAL_DATUM_INFO_USER_HEADER_PARAM, ":", TRUE, FALSE, ';');
         if (compressed) {
             do {
@@ -1941,7 +1942,9 @@ int* copyVdiFromLocationStructToUserHeader(
                     }
                 }
                 free(compressed);
-                free(userHeader);
+                if (freeOriginalHeader) {
+                    free(userHeader);
+                }
                 userHeader = stringToUserHeader(headerBuf, userHeaderNumber);
                 free(headerBuf);
             } while (FALSE);

--- a/heclib/heclib_c/src/headers/hecdssInternal.h
+++ b/heclib/heclib_c/src/headers/hecdssInternal.h
@@ -37,7 +37,7 @@
 
 
 #define DSS_VERSION "7-IQ"
-#define DSS_VERSION_DATE "1 January 2023"
+#define DSS_VERSION_DATE "6 January 2023"
 
 
 

--- a/heclib/heclib_c/src/headers/hecdssInternal.h
+++ b/heclib/heclib_c/src/headers/hecdssInternal.h
@@ -37,7 +37,7 @@
 
 
 #define DSS_VERSION "7-IQ"
-#define DSS_VERSION_DATE "6 January 2023"
+#define DSS_VERSION_DATE "9 January 2023"
 
 
 

--- a/heclib/heclib_c/src/headers/verticalDatum.h
+++ b/heclib/heclib_c/src/headers/verticalDatum.h
@@ -593,12 +593,15 @@ char* processStorageVdis(
  * @param userHeader       The user header integer array
  * @param userHeaderNumber The number of ints in the user header
  * @param status           Receives 0 on success or < 0 on error
+ * @param freeOriginalHeader Flag to specify whether to free the original header if a new header is allocated
+ *                           in order to provide enough space for the VDI
  * @return The (possibly reallocated) user header on success
  */
 int* copyVdiFromLocationStructToUserHeader(
     zStructLocation* locStruct,
     int* userHeader,
     int* userHeaderNumber,
+    int freeOriginalHeader,
     int* status);
 
 #ifdef __cplusplus

--- a/heclib/heclib_c/src/headers/verticalDatum.h
+++ b/heclib/heclib_c/src/headers/verticalDatum.h
@@ -604,6 +604,37 @@ int* copyVdiFromLocationStructToUserHeader(
     int freeOriginalHeader,
     int* status);
 
+/**
+ * Returns whether a DSS pathname is an elevation time series. Really only test whether the C pathname
+ * part is "Elev"; no other tests are performed.
+ * 
+ * @param pathname The pathname to test
+ * @return whether the C pathname part starts with "Elev" (case insensitive)
+ */
+int pathnameIsElevTs(const char* pathname);
+
+/**
+ * Returns whether a DSS pathname is paired data with elevation in independent or dependent parameter. Really only test the C pathname
+ * part to see if either parameter starts with "Elev"; no other tests are performed.
+ *
+ * @param pathname The pathname to test
+ * @return <ul>
+ *         <li><b>0</b> if neither parameter is elevation</li>
+ *         <li><b>1</b> if only independent parameter is elevation</li>
+ *         <li><b>2</b> if only dependent parameter is elevation</li>
+ *         <li><b>3</b> if both independent and dependent parameters are elevation</li>
+ *         </ul>
+ */
+int pathnameIsElevPd(const char* pathname);
+
+/**
+ * Returns whether a DSS pathname is an elevation time sereis or paired data. Really only tests the C pathname part
+ *
+ * @param pathname The pathname to test
+ * @return whether either parameter in the C pathname part starts with "Elev" (case insensitive)
+ */
+int pathnameIsElevTsOrPd(const char* pathname);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/heclib/heclib_c/src/headers/verticalDatum.h
+++ b/heclib/heclib_c/src/headers/verticalDatum.h
@@ -7,7 +7,7 @@ extern "C" {
  
 #include <float.h>
 #include <stdint.h>
-
+#include <zStructLocation.h>
  
 #define F2C(f, c, flen, clen) {                    \
     int len = flen < clen ? flen : clen - 1;       \
@@ -586,6 +586,20 @@ char* processStorageVdis(
     const char*              currentDatum,
     int                      fileContainsData,
     const char*              dataUnit);
+
+/**
+ * Copies any VDI from a location struct to a user header. Used for copying DSS 7 records to DSS 6
+ * @param locStruct        The location struct 
+ * @param userHeader       The user header integer array
+ * @param userHeaderNumber The number of ints in the user header
+ * @param status           Receives 0 on success or < 0 on error
+ * @return The (possibly reallocated) user header on success
+ */
+int* copyVdiFromLocationStructToUserHeader(
+    zStructLocation* locStruct,
+    int* userHeader,
+    int* userHeaderNumber,
+    int* status);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/heclib/heclib_f/heclib_f.vfproj
+++ b/heclib/heclib_f/heclib_f.vfproj
@@ -179,6 +179,7 @@
 		<File RelativePath=".\src\Support\cjchr.f"/>
 		<File RelativePath=".\src\Support\convi4toi8.f"/>
 		<File RelativePath=".\src\Support\convi8toi4.f"/>
+		<File RelativePath=".\src\Support\crack_unit_spec.f"/>
 		<File RelativePath=".\src\Support\curtim.f"/>
 		<File RelativePath=".\src\Support\datcll.f"/>
 		<File RelativePath=".\src\Support\datcln.f"/>
@@ -259,7 +260,6 @@
 		<File RelativePath=".\src\Support\xrealc.f"/>
 		<File RelativePath=".\src\Support\xreald.f"/>
 		<File RelativePath=".\src\Support\ymddat.f"/></Filter>
-		<File RelativePath=".\src\Support\crack_unit_spec.f"/>
 		<File RelativePath=".\src\dssCopyStatus.f"/>
 		<File RelativePath=".\src\Support\get_user_header_param.f"/>
 		<File RelativePath=".\src\getCurrentRec.f"/>

--- a/heclib/heclib_f/src/zritsi6.f
+++ b/heclib/heclib_f/src/zritsi6.f
@@ -79,16 +79,12 @@ C
       INTEGER IFORWD, INTLPS
       data lgetq /.false./
 C
-C     Pathname variable dimensions
-      character*64 ca, cb, cc, cd, ce, cf
-      integer na, nb, nc, nd, ne, nf, npath
-C
 C     Vertical datum varible dimensions
       character*400 vdiStr, errMsg
       character*16 nativeDatum, prevVerticalDatum, unit, cvdatum1
       double precision offsetNavd88, offsetNgvd29, vertDatumOffset
       logical l_Navd88Estimated, l_Ngvd29Estimated
-      integer vdiStrLen
+      integer vdiStrLen, paramIsElev
 C
 C
 C
@@ -445,10 +441,8 @@ C
       ! get the vertical datum offset if necessary !
       !--------------------------------------------!
       vertDatumOffset = 0
-      call zufpn(ca, na, cb, nb, cc, nc, cd, nd, ce, ne, cf, nf,
-     *           cpath1, len_trim(cpath1), istat)
-      call upcase(cc)
-      if (index(cc, 'ELEV').eq.1) then
+      call pathnameIsElevTs(cpath1, paramIsElev)
+      if (paramIsElev.eq.1) then
         !--------------------------!
         ! time series is elevation !
         !--------------------------!

--- a/heclib/heclib_f/src/zrpdi6.f
+++ b/heclib/heclib_f/src/zrpdi6.f
@@ -19,12 +19,8 @@ C
       LOGICAL LFOUND, LABEL, LDOUBLE, LEND
       LOGICAL LFILDOB
 C
-C     Pathname variable dimensions
-      character*64 ca, cb, cc, cd, ce, cf
-      integer na, nb, nc, nd, ne, nf, npath
-C
 C     Vertical datum varible dimensions
-      integer iuhead_copy(100)
+      integer iuhead_copy(100), paramIsElev
       character*400 vdiStr, errMsg
       character*16 unit
       character*16 nativeDatum, cvdatum1
@@ -241,17 +237,9 @@ C
       !---------------------------------------------------------!
       ! convert values to requested vertical datum if necessary !
       !---------------------------------------------------------!
-      l_indElev = .false.
-      l_depElev = .false.
-      call zufpn(ca, na, cb, nb, cc, nc, cd, nd, ce, ne, cf, nf,
-     *           cpath, len_trim(cpath), jstat)
-      call upcase(cc)
-      if (index(cc, 'ELEV').eq.1) then
-        l_indElev = .true.
-      end if
-      if (index(cc, '-ELEV').gt.0) then
-        l_depElev = .true.
-      endif
+      call pathnameIsElevPd(cpath, paramIsElev)
+      l_indElev = (paramIsElev.eq.1).or.(paramIsElev.eq.3)
+      l_depElev = (paramIsElev.eq.2).or.(paramIsElev.eq.3)
       if (l_indElev.or.l_depElev) then
         !------------------------------------------------------!
         ! paired data has elevation in ordinates and/or values !

--- a/heclib/heclib_f/src/zrrtsi.f
+++ b/heclib/heclib_f/src/zrrtsi.f
@@ -80,16 +80,12 @@ C     Local Dimensions
 	PARAMETER (KIHEAD = 24)
       INTEGER IIHEAD(KIHEAD)
 C
-C     Pathname variable dimensions
-      character*64 ca, cb, cc, cd, ce, cf
-      integer na, nb, nc, nd, ne, nf, npath
-C
 C     Vertical datum varible dimensions
       character*400 vdiStr, errMsg
       character*16 nativeDatum, unit, cvdatum1, prevVerticalDatum
       double precision offsetNavd88, offsetNgvd29, vertDatumOffset
       logical l_Navd88Estimated, l_Ngvd29Estimated
-      integer vdiStrLen
+      integer vdiStrLen, paramIsElev
 C
       data lqblok /.false./
 
@@ -400,10 +396,8 @@ C
       !---------------------------------------------------------!
       ! convert values to requested vertical datum if necessary !
       !---------------------------------------------------------!
-      call zufpn(ca, na, cb, nb, cc, nc, cd, nd, ce, ne, cf, nf,
-     *           cpath, len_trim(cpath), iistat)
-      call upcase(cc)
-      if (index(cc, 'ELEV').eq.1) then
+      call pathnameIsElevTs(cpath, paramIsElev)
+      if (paramIsElev.eq.1) then
         !--------------------------!
         ! time series is elevation !
         !--------------------------!

--- a/heclib/heclib_f/src/zsitsi6.f
+++ b/heclib/heclib_f/src/zsitsi6.f
@@ -69,7 +69,7 @@ C     Vertical datum varible dimensions
       logical*4 l_modified, l_exists
       integer nuhead_copy1, iuhead_copy1(100)
       integer nuhead_copy2, iuhead_copy2(100)
-      integer na, nb, nc, nd, ne, nf
+      integer na, nb, nc, nd, ne, nf, paramIsElev
 C
       data cpath_this /' '/, ibsize /0/, jbsize /0/
 C
@@ -282,9 +282,8 @@ C
       !-----------------------------------------------!
       ! convert to native vertical datum if necessary !
       !-----------------------------------------------!
-      cc = cpath(ibpart(3):iepart(3))
-      call upcase(cc)
-      if (index(cc,'ELEV').eq.1) then
+      call pathnameIsElevTs(cpath, paramIsElev)
+      if (paramIsElev.eq.1) then
         !-----------------------!
         ! elevation time series !
         !-----------------------!

--- a/heclib/heclib_f/src/zspdi6.f
+++ b/heclib/heclib_f/src/zspdi6.f
@@ -35,17 +35,13 @@ C
       LOGICAL LABEL, LFOUND, LDOUBLE
       INTEGER MAXLABEL
 C
-C     Pathname variable dimensions
-      character*64 ca, cb, cc, cd, ce, cf
-      integer na, nb, nc, nd, ne, nf, npath
-C
 C     Vertical datum varible dimensions
       character*400 fileVdiStr, dataVdiStr, errMsg
       character*16 unit, cvdatum1, cvdatum2
       character*16 cvdatum_ind, cvdatum_dep
       double precision vertDatumOffset_ind, vertDatumOffset_dep
       logical*4 l_indElev, l_depElev, l_ordsModified, l_valsModified
-      integer nuhead_copy1, iuhead_copy1(100)
+      integer nuhead_copy1, iuhead_copy1(100), paramIsElev
       integer nuhead_copy2, iuhead_copy2(100)
 C
       INCLUDE 'zdssmz.h'
@@ -105,19 +101,11 @@ C     Check that IFLTAB is valid (e.g., the DSS file is open)
       !--------------------------------------------------------------!
       ! convert the values to the native vertical datum if necessary !
       !--------------------------------------------------------------!
-      l_indElev = .false.
-      l_depElev = .false.
       l_ordsModified = .false.
       l_valsModified = .false.
-      call zufpn(ca, na, cb, nb, cc, nc, cd, nd, ce, ne, cf, nf,
-     *           cpath, len_trim(cpath), istat)
-      call upcase(cc)
-      if (index(cc, 'ELEV').eq.1) then
-        l_indElev = .true.
-      end if
-      if (index(cc, '-ELEV').gt.0) then
-        l_depElev = .true.
-      endif
+      call pathnameIsElevPd(cpath, paramIsElev)
+      l_indElev = (paramIsElev.eq.1).or.(paramIsElev.eq.3)
+      l_depElev = (paramIsElev.eq.2).or.(paramIsElev.eq.3)
       if (l_indElev.or.l_depElev) then
         !----------------------------------!
         ! elevation in ordinates or values !

--- a/heclib/heclib_f/src/zsrtsi6.f
+++ b/heclib/heclib_f/src/zsrtsi6.f
@@ -83,6 +83,7 @@ C     Vertical datum varible dimensions
       logical*4 l_modified, l_exists
       integer nuhead_copy1, iuhead_copy1(100)
       integer nuhead_copy2, iuhead_copy2(100)
+      integer paramIsElev
 C
       data cpath_this /' '/
 C
@@ -248,9 +249,8 @@ C
       !-----------------------------------------------!
       ! convert to native vertical datum if necessary !
       !-----------------------------------------------!
-      cc = cpart(3)
-      call upcase(cc)
-      if (index(cc,'ELEV').eq.1) then
+      call pathnameIsElevTs(cpath, paramIsElev)
+      if (paramIsElev.eq.1) then
         !-----------------------!
         ! elevation time series !
         !-----------------------!

--- a/test/Dss-C/TestDssC.c
+++ b/test/Dss-C/TestDssC.c
@@ -180,29 +180,30 @@ int runTheTests() {
 	char fileName6[80];
 	int status;
 
-	status = miscTests();
-	if (status != STATUS_OKAY)
-		return status;
+	//status = miscTests();
+	//if (status != STATUS_OKAY)
+	//	return status;
 
 
-	status = gridMemoryTest();
-	if (status != STATUS_OKAY)
-		return status;
+	//status = gridMemoryTest();
+	//if (status != STATUS_OKAY)
+	//	return status;
 
-	status = units_issue_126();
-	if (status != STATUS_OKAY)
-		return status;
+	//status = units_issue_126();
+	//if (status != STATUS_OKAY)
+	//	return status;
 
 
-	printf("\ntest format F part with tags\n");
-	status = test_normalize_f_part();
-	if (status != STATUS_OKAY)
-		return status;
+	//printf("\ntest format F part with tags\n");
+	//status = test_normalize_f_part();
+	//if (status != STATUS_OKAY)
+	//	return status;
 
 	printf("\ntest vertical datum operations (C API)\n");
 	status = test_vertical_datums_c();
 	if (status != STATUS_OKAY)
 		return status;
+	return status;
 
 	status = PathnameTesting("path_name_test7.dss",7);
 	status = PathnameTesting("path_name_test6.dss", 6);

--- a/test/Dss-C/TestDssC.c
+++ b/test/Dss-C/TestDssC.c
@@ -180,30 +180,29 @@ int runTheTests() {
 	char fileName6[80];
 	int status;
 
-	//status = miscTests();
-	//if (status != STATUS_OKAY)
-	//	return status;
+	status = miscTests();
+	if (status != STATUS_OKAY)
+		return status;
 
 
-	//status = gridMemoryTest();
-	//if (status != STATUS_OKAY)
-	//	return status;
+	status = gridMemoryTest();
+	if (status != STATUS_OKAY)
+		return status;
 
-	//status = units_issue_126();
-	//if (status != STATUS_OKAY)
-	//	return status;
+	status = units_issue_126();
+	if (status != STATUS_OKAY)
+		return status;
 
 
-	//printf("\ntest format F part with tags\n");
-	//status = test_normalize_f_part();
-	//if (status != STATUS_OKAY)
-	//	return status;
+	printf("\ntest format F part with tags\n");
+	status = test_normalize_f_part();
+	if (status != STATUS_OKAY)
+		return status;
 
 	printf("\ntest vertical datum operations (C API)\n");
 	status = test_vertical_datums_c();
 	if (status != STATUS_OKAY)
 		return status;
-	return status;
 
 	status = PathnameTesting("path_name_test7.dss",7);
 	status = PathnameTesting("path_name_test6.dss", 6);

--- a/test/Dss-C/source/testVerticalDatum_c.c
+++ b/test/Dss-C/source/testVerticalDatum_c.c
@@ -3,6 +3,7 @@
 #include <ctype.h>
 #include <heclib.h>
 #include <verticalDatum.h>
+#include <math.h>
 
 void testDelimitedStringOps();
 void testGzipAndEncodingOps();
@@ -2271,8 +2272,9 @@ void retrieveAndCompareVdi(long long *ifltab, const char* pathname, const void *
     }
 }
 
-void testCopyRecordWithVdi() {
-    long long ifltab[2][250] = { 0 };
+void testCopyRecordWithVdi_NoVdiInDestination() {
+    long long ifltab[2][250];
+    memset(ifltab, 0, sizeof(ifltab));
     int status;
     zStructTimeSeries* tss = NULL;
     zStructPairedData* pds = NULL;
@@ -2352,8 +2354,6 @@ void testCopyRecordWithVdi() {
         ""
 
     };
-
-    zset("MLVL", "", 1);
 
     for (int srcDssVer = 6; srcDssVer <= 7; ++srcDssVer) {
         for (int dstDssVer = 6; dstDssVer <= 7; ++dstDssVer) {
@@ -2525,3 +2525,596 @@ void testCopyRecordWithVdi() {
     remove(filename[SRC]);
     remove(filename[DST]);
 }
+
+void testCopyRecordWithVdi_OtherNativeDatumInDestination() {
+    long long ifltab[2][250];
+    memset(ifltab, 0, sizeof(ifltab));
+    int status;
+    zStructTimeSeries* tss = NULL;
+    zStructPairedData* pds = NULL;
+    verticalDatumInfo vdi[2];
+    memset(vdi, 0, sizeof(vdi));
+    const char* filename[2] = { "vdiCopyTestSource.dss", "vdiCopyTestDestination.dss" };
+    const char* tsPathname[2] = { "//TsSourceLoc/Elev/01Oct2021/1Hour/Test/", "//TsDestinationLoc/Elev/01Oct2021/1Hour/Test/" };
+    const char* pdPathname[2] = { "//PdSourceLoc/Stage-Elev///Test/", "//TsDestinationLoc/Stage-Elev///Test/" };
+    double tsValues[] = { 1000,1001,1002,1003,1004,1005 };
+    int numberTsValues = sizeof(tsValues) / sizeof(tsValues[0]);
+    double pdOrdinates[] = { 1000,1001,1002,1003,1004,1005 };
+    double pdValues[] = { 1000,1001,1002,1003,1004,1005 };
+    int numberPdOrdinates = 6;
+    int numberPdCurves = 1;
+    char* startDate = "01Oct2021";
+    char* startTime = "01:00";
+    char* endDate = "01Oct2021";
+    char* endTime = "24:00";
+    char* unit = "ft";
+    char* type = "INST-VAL";
+    char* errmsg = NULL;
+    char* compressed = NULL;
+    char* headerBuf = NULL;
+    int   len = 0;
+    int   dssver;
+    char* vdiXml = NULL;
+    char* xml[] = {
+        "<vertical-datum-info unit=\"ft\">\n"
+        "  <native-datum>NGVD-29</native-datum>\n"
+        "  <elevation>615.2</elevation>\n"
+        "  <offset estimate=\"true\">\n"
+        "    <to-datum>NAVD-88</to-datum>\n"
+        "    <value>0.3855</value>\n"
+        "  </offset>\n"
+        "</vertical-datum-info>\n",
+
+        "<vertical-datum-info unit=\"ft\">\n"
+        "  <native-datum>NAVD-88</native-datum>\n"
+        "  <elevation>615.5885</elevation>\n"
+        "  <offset estimate=\"true\">\n"
+        "    <to-datum>NGVD-29</to-datum>\n"
+        "    <value>-0.3855</value>\n"
+        "  </offset>\n"
+        "</vertical-datum-info>\n"
+    };
+    int xmlCount = sizeof(xml) / sizeof(xml[0]);
+
+    for (int srcDssVer = 6; srcDssVer <= 7; ++srcDssVer) {
+        for (int dstDssVer = 6; dstDssVer <= 7; ++dstDssVer) {
+
+            remove(filename[SRC]);
+            if (srcDssVer == 6) {
+                status = zopen6(ifltab[SRC], filename[SRC]);
+            }
+            else {
+                status = zopen7(ifltab[SRC], filename[SRC]);
+            }
+            assert(status == STATUS_OKAY);
+            dssver = (int)zgetVersion(ifltab[SRC]);
+
+            remove(filename[DST]);
+            if (dstDssVer == 6) {
+                status = zopen6(ifltab[DST], filename[DST]);
+            }
+            else {
+                status = zopen7(ifltab[DST], filename[DST]);
+            }
+            assert(status == STATUS_OKAY);
+
+            for (int i = 0; i < xmlCount; ++i) {
+                int j = (i + 1) % xmlCount; // for other VDI
+                printf("\n-------------------------------\n%3d\n-------------------------------\n", i);
+                stringToVerticalDatumInfo(&vdi[SRC], xml[i]);
+                printf("==> Source (v%d) : %s\n", dssver, vdi[i].nativeDatum);
+                //-----------------------------//
+                // create a source time series //
+                //-----------------------------//
+                tss = zstructTsNewRegDoubles(
+                    tsPathname[SRC],
+                    tsValues,
+                    numberTsValues,
+                    startDate,
+                    startTime,
+                    unit,
+                    type);
+                assert(tss != NULL);
+                //-----------------------------//
+                // create a source paired data //
+                //-----------------------------//
+                pds = zstructPdNewDoubles(
+                    pdPathname[SRC],
+                    pdOrdinates,
+                    pdValues,
+                    numberPdOrdinates,
+                    numberPdCurves,
+                    unit,
+                    "UNT",
+                    unit,
+                    "UNT");
+                //-----------------------------------------------//
+                // add VDI to source time series and paired data //
+                //-----------------------------------------------//
+                stringToVerticalDatumInfo(&vdi[SRC], xml[i]);
+                errmsg = gzipAndEncode(&compressed, xml[i]);
+                assert(errmsg == NULL);
+                len = VERTICAL_DATUM_INFO_USER_HEADER_PARAM_LEN + strlen(compressed) + 2;
+                headerBuf = (char*)malloc(len + 1);
+                assert(headerBuf != NULL);
+                memset(headerBuf, 0, len + 1);
+                status = insertIntoDelimitedString(
+                    &headerBuf,
+                    len + 1,
+                    VERTICAL_DATUM_INFO_USER_HEADER_PARAM,
+                    compressed,
+                    ":",
+                    FALSE,
+                    ';');
+                assert(status == STATUS_OKAY);
+                free(compressed);
+                tss->userHeader = stringToUserHeader(headerBuf, &tss->userHeaderNumber);
+                tss->allocated[zSTRUCT_userHeader] = TRUE;
+                pds->userHeader = stringToUserHeader(headerBuf, &pds->userHeaderNumber);
+                pds->allocated[zSTRUCT_userHeader] = TRUE;
+                //-----------------------------//
+                // delete any previous records //
+                //-----------------------------//
+                zdelete(ifltab[SRC], tsPathname[SRC]);
+                zdelete(ifltab[SRC], zlocationPath(tsPathname[SRC]));
+                zdelete(ifltab[SRC], pdPathname[SRC]);
+                zdelete(ifltab[SRC], zlocationPath(pdPathname[SRC]));
+                //-----------------------------------------------------//
+                // store the source time series to the source DSS file //
+                //-----------------------------------------------------//
+                status = ztsStore(
+                    ifltab[SRC], // file table
+                    tss,         // time series struct
+                    0);          // storage flag (0=reg:replace all, irr:merge)
+                assert(status == STATUS_OKAY);
+                zstructFree(tss);
+                //------------------------------//
+                // store the source paired data //
+                //------------------------------//
+                status = zpdStore(ifltab[SRC], pds, 0);
+                assert(status == STATUS_OKAY);
+                zstructFree(pds);
+
+                //----------------------------------//
+                // create a destination time series //
+                //----------------------------------//
+                tss = zstructTsNewRegDoubles(
+                    tsPathname[DST],
+                    tsValues,
+                    numberTsValues,
+                    startDate,
+                    startTime,
+                    unit,
+                    type);
+                assert(tss != NULL);
+                //----------------------------------//
+                // create a destination paired data //
+                //----------------------------------//
+                pds = zstructPdNewDoubles(
+                    pdPathname[DST],
+                    pdOrdinates,
+                    pdValues,
+                    numberPdOrdinates,
+                    numberPdCurves,
+                    unit,
+                    "UNT",
+                    unit,
+                    "UNT");
+                //----------------------------------------------------//
+                // add VDI to destination time series and paired data //
+                //----------------------------------------------------//
+                stringToVerticalDatumInfo(&vdi[DST], xml[j]);
+                errmsg = gzipAndEncode(&compressed, xml[j]);
+                assert(errmsg == NULL);
+                len = VERTICAL_DATUM_INFO_USER_HEADER_PARAM_LEN + strlen(compressed) + 2;
+                headerBuf = (char*)malloc(len + 1);
+                assert(headerBuf != NULL);
+                memset(headerBuf, 0, len + 1);
+                status = insertIntoDelimitedString(
+                    &headerBuf,
+                    len + 1,
+                    VERTICAL_DATUM_INFO_USER_HEADER_PARAM,
+                    compressed,
+                    ":",
+                    FALSE,
+                    ';');
+                assert(status == STATUS_OKAY);
+                free(compressed);
+                tss->userHeader = stringToUserHeader(headerBuf, &tss->userHeaderNumber);
+                tss->allocated[zSTRUCT_userHeader] = TRUE;
+                pds->userHeader = stringToUserHeader(headerBuf, &pds->userHeaderNumber);
+                pds->allocated[zSTRUCT_userHeader] = TRUE;
+                //-----------------------------//
+                // delete any previous records //
+                //-----------------------------//
+                zdelete(ifltab[SRC], tsPathname[DST]);
+                zdelete(ifltab[SRC], zlocationPath(tsPathname[DST]));
+                zdelete(ifltab[SRC], pdPathname[DST]);
+                zdelete(ifltab[SRC], zlocationPath(pdPathname[DST]));
+                zdelete(ifltab[DST], tsPathname[DST]);
+                zdelete(ifltab[DST], zlocationPath(tsPathname[DST]));
+                zdelete(ifltab[DST], pdPathname[DST]);
+                zdelete(ifltab[DST], zlocationPath(pdPathname[DST]));
+                //----------------------------------------------------------//
+                // store the destination time series to the source DSS file //
+                //----------------------------------------------------------//
+                status = ztsStore(
+                    ifltab[SRC], // file table
+                    tss,         // time series struct
+                    0);          // storage flag (0=reg:replace all, irr:merge)
+                assert(status == STATUS_OKAY);
+                //---------------------------------------------------------------//
+                // store the destination time series to the destination DSS file //
+                //---------------------------------------------------------------//
+                status = ztsStore(
+                    ifltab[DST], // file table
+                    tss,         // time series struct
+                    0);          // storage flag (0=reg:replace all, irr:merge)
+                assert(status == STATUS_OKAY);
+                //----------------------------------------------------------//
+                // store the destination paired data to the source DSS file //
+                //----------------------------------------------------------//
+                status = zpdStore(ifltab[SRC], pds, 0);
+                assert(status == STATUS_OKAY);
+                //---------------------------------------------------------------//
+                // store the destination paired data to the destination DSS file //
+                //---------------------------------------------------------------//
+                status = zpdStore(ifltab[DST], pds, 0);
+                assert(status == STATUS_OKAY);
+                zstructFree(tss);
+                zstructFree(pds);
+                //-------------------------------------------------------------------------------------------//
+                // copy the time series to a location in the same DSS file that has a different native datum //
+                //-------------------------------------------------------------------------------------------//
+                printf("==> %s:%s (v%d)\n", filename[SRC], tsPathname[DST], dstDssVer);
+                status = zcopyRecord(ifltab[SRC], ifltab[SRC], tsPathname[SRC], tsPathname[DST]);
+                assert(status != STATUS_OKAY);
+                //-------------------------------------------------------------------------------------------//
+                // copy the paired data to a location in the same DSS file that has a different native datum //
+                //-------------------------------------------------------------------------------------------//
+                printf("==> %s:%s (v%d)\n", filename[SRC], pdPathname[DST], dstDssVer);
+                status = zcopyRecord(ifltab[SRC], ifltab[SRC], pdPathname[SRC], pdPathname[DST]);
+                assert(status != STATUS_OKAY);
+                //------------------------------------------------------------------------------------------//
+                // copy the time series to a location in another DSS file that has a different native datum //
+                //------------------------------------------------------------------------------------------//
+                printf("==> %s:%s (v%d)\n", filename[DST], tsPathname[DST], dstDssVer);
+                status = zcopyRecord(ifltab[SRC], ifltab[DST], tsPathname[SRC], tsPathname[DST]);
+                assert(status != STATUS_OKAY);
+                //------------------------------------------------------------------------------------------//
+                // copy the paired data to a location in another DSS file that has a different native datum //
+                //------------------------------------------------------------------------------------------//
+                printf("==> %s:%s (v%d)\n", filename[DST], pdPathname[DST], dstDssVer);
+                status = zcopyRecord(ifltab[SRC], ifltab[DST], pdPathname[SRC], pdPathname[DST]);
+                assert(status != STATUS_OKAY);
+            }
+            zclose(ifltab[SRC]);
+            zclose(ifltab[DST]);
+        }
+    }
+    remove(filename[SRC]);
+    remove(filename[DST]);
+}
+
+void testCopyRecordWithVdi_SameNativeDatumInDestination() {
+    long long ifltab[2][250];
+    memset(ifltab, 0, sizeof(ifltab));
+    int status;
+    zStructTimeSeries* tss = NULL;
+    zStructPairedData* pds = NULL;
+    verticalDatumInfo vdi;
+    const char* filename[2] = { "vdiCopyTestSource.dss", "vdiCopyTestDestination.dss" };
+    const char* tsPathname[2] = { "//TsSourceLoc/Elev/01Oct2021/1Hour/Test/", "//TsDestinationLoc/Elev/01Oct2021/1Hour/Test/" };
+    const char* pdPathname[2] = { "//PdSourceLoc/Stage-Elev///Test/", "//TsDestinationLoc/Stage-Elev///Test/" };
+    double tsValues[2][6] = { { 1000,1001,1002,1003,1004,1005 }, {1,2,3,4,5} };
+    int numberTsValues = 6;
+    double pdOrdinates[] = { 1000,1001,1002,1003,1004,1005 };
+    double pdValues[2][6] = { {1000,1001,1002,1003,1004,1005}, {1,2,3,4,5} };
+    int numberPdOrdinates = 6;
+    int numberPdCurves = 1;
+    char* startDate = "01Oct2021";
+    char* startTime = "01:00";
+    char* endDate = "01Oct2021";
+    char* endTime = "24:00";
+    char* unit = "ft";
+    char* type = "INST-VAL";
+    char* errmsg = NULL;
+    char* compressed = NULL;
+    char* headerBuf = NULL;
+    int   len = 0;
+    int   dssver;
+    int   i;
+    char* vdiXml = NULL;
+    char* xml = {
+        "<vertical-datum-info unit=\"ft\">\n"
+        "  <native-datum>NGVD-29</native-datum>\n"
+        "  <elevation>615.2</elevation>\n"
+        "  <offset estimate=\"true\">\n"
+        "    <to-datum>NAVD-88</to-datum>\n"
+        "    <value>0.3855</value>\n"
+        "  </offset>\n"
+        "</vertical-datum-info>\n"
+    };
+
+    for (int srcDssVer = 6; srcDssVer <= 7; ++srcDssVer) {
+        for (int dstDssVer = 6; dstDssVer <= 7; ++dstDssVer) {
+
+            remove(filename[SRC]);
+            if (srcDssVer == 6) {
+                status = zopen6(ifltab[SRC], filename[SRC]);
+            }
+            else {
+                status = zopen7(ifltab[SRC], filename[SRC]);
+            }
+            assert(status == STATUS_OKAY);
+            dssver = (int)zgetVersion(ifltab[SRC]);
+
+            remove(filename[DST]);
+            if (dstDssVer == 6) {
+                status = zopen6(ifltab[DST], filename[DST]);
+            }
+            else {
+                status = zopen7(ifltab[DST], filename[DST]);
+            }
+            assert(status == STATUS_OKAY);
+
+            stringToVerticalDatumInfo(&vdi, xml);
+            printf("==> Source (v%d) : %s\n", dssver, vdi.nativeDatum);
+            //-----------------------------//
+            // create a source time series //
+            //-----------------------------//
+            tss = zstructTsNewRegDoubles(
+                tsPathname[SRC],
+                tsValues[SRC],
+                numberTsValues,
+                startDate,
+                startTime,
+                unit,
+                type);
+            assert(tss != NULL);
+            //-----------------------------//
+            // create a source paired data //
+            //-----------------------------//
+            pds = zstructPdNewDoubles(
+                pdPathname[SRC],
+                pdOrdinates,
+                pdValues[SRC],
+                numberPdOrdinates,
+                numberPdCurves,
+                unit,
+                "UNT",
+                unit,
+                "UNT");
+            //-----------------------------------------------//
+            // add VDI to source time series and paired data //
+            //-----------------------------------------------//
+            stringToVerticalDatumInfo(&vdi, xml);
+            errmsg = gzipAndEncode(&compressed, xml);
+            assert(errmsg == NULL);
+            len = VERTICAL_DATUM_INFO_USER_HEADER_PARAM_LEN + strlen(compressed) + 2;
+            headerBuf = (char*)malloc(len + 1);
+            assert(headerBuf != NULL);
+            memset(headerBuf, 0, len + 1);
+            status = insertIntoDelimitedString(
+                &headerBuf,
+                len + 1,
+                VERTICAL_DATUM_INFO_USER_HEADER_PARAM,
+                compressed,
+                ":",
+                FALSE,
+                ';');
+            assert(status == STATUS_OKAY);
+            free(compressed);
+            tss->userHeader = stringToUserHeader(headerBuf, &tss->userHeaderNumber);
+            tss->allocated[zSTRUCT_userHeader] = TRUE;
+            pds->userHeader = stringToUserHeader(headerBuf, &pds->userHeaderNumber);
+            pds->allocated[zSTRUCT_userHeader] = TRUE;
+            //-----------------------------//
+            // delete any previous records //
+            //-----------------------------//
+            zdelete(ifltab[SRC], tsPathname[SRC]);
+            zdelete(ifltab[SRC], zlocationPath(tsPathname[SRC]));
+            zdelete(ifltab[SRC], pdPathname[SRC]);
+            zdelete(ifltab[SRC], zlocationPath(pdPathname[SRC]));
+            //-----------------------------------------------------//
+            // store the source time series to the source DSS file //
+            //-----------------------------------------------------//
+            status = ztsStore(
+                ifltab[SRC], // file table
+                tss,         // time series struct
+                0);          // storage flag (0=reg:replace all, irr:merge)
+            assert(status == STATUS_OKAY);
+            zstructFree(tss);
+            //------------------------------//
+            // store the source paired data //
+            //------------------------------//
+            status = zpdStore(ifltab[SRC], pds, 0);
+            assert(status == STATUS_OKAY);
+            zstructFree(pds);
+
+            //----------------------------------//
+            // create a destination time series //
+            //----------------------------------//
+            tss = zstructTsNewRegDoubles(
+                tsPathname[DST],
+                tsValues[DST],
+                numberTsValues,
+                startDate,
+                startTime,
+                unit,
+                type);
+            assert(tss != NULL);
+            //----------------------------------//
+            // create a destination paired data //
+            //----------------------------------//
+            pds = zstructPdNewDoubles(
+                pdPathname[DST],
+                pdOrdinates,
+                pdValues[DST],
+                numberPdOrdinates,
+                numberPdCurves,
+                unit,
+                "UNT",
+                unit,
+                "UNT");
+            //----------------------------------------------------//
+            // add VDI to destination time series and paired data //
+            //----------------------------------------------------//
+            stringToVerticalDatumInfo(&vdi, xml);
+            errmsg = gzipAndEncode(&compressed, xml);
+            assert(errmsg == NULL);
+            len = VERTICAL_DATUM_INFO_USER_HEADER_PARAM_LEN + strlen(compressed) + 2;
+            headerBuf = (char*)malloc(len + 1);
+            assert(headerBuf != NULL);
+            memset(headerBuf, 0, len + 1);
+            status = insertIntoDelimitedString(
+                &headerBuf,
+                len + 1,
+                VERTICAL_DATUM_INFO_USER_HEADER_PARAM,
+                compressed,
+                ":",
+                FALSE,
+                ';');
+            assert(status == STATUS_OKAY);
+            free(compressed);
+            tss->userHeader = stringToUserHeader(headerBuf, &tss->userHeaderNumber);
+            tss->allocated[zSTRUCT_userHeader] = TRUE;
+            pds->userHeader = stringToUserHeader(headerBuf, &pds->userHeaderNumber);
+            pds->allocated[zSTRUCT_userHeader] = TRUE;
+            //-----------------------------//
+            // delete any previous records //
+            //-----------------------------//
+            zdelete(ifltab[SRC], tsPathname[DST]);
+            zdelete(ifltab[SRC], zlocationPath(tsPathname[DST]));
+            zdelete(ifltab[SRC], pdPathname[DST]);
+            zdelete(ifltab[SRC], zlocationPath(pdPathname[DST]));
+            zdelete(ifltab[DST], tsPathname[DST]);
+            zdelete(ifltab[DST], zlocationPath(tsPathname[DST]));
+            zdelete(ifltab[DST], pdPathname[DST]);
+            zdelete(ifltab[DST], zlocationPath(pdPathname[DST]));
+            //----------------------------------------------------------//
+            // store the destination time series to the source DSS file //
+            //----------------------------------------------------------//
+            status = ztsStore(
+                ifltab[SRC], // file table
+                tss,         // time series struct
+                0);          // storage flag (0=reg:replace all, irr:merge)
+            assert(status == STATUS_OKAY);
+            //---------------------------------------------------------------//
+            // store the destination time series to the destination DSS file //
+            //---------------------------------------------------------------//
+            status = ztsStore(
+                ifltab[DST], // file table
+                tss,         // time series struct
+                0);          // storage flag (0=reg:replace all, irr:merge)
+            assert(status == STATUS_OKAY);
+            //----------------------------------------------------------//
+            // store the destination paired data to the source DSS file //
+            //----------------------------------------------------------//
+            status = zpdStore(ifltab[SRC], pds, 0);
+            assert(status == STATUS_OKAY);
+            //---------------------------------------------------------------//
+            // store the destination paired data to the destination DSS file //
+            //---------------------------------------------------------------//
+            status = zpdStore(ifltab[DST], pds, 0);
+            assert(status == STATUS_OKAY);
+            zstructFree(tss);
+            zstructFree(pds);
+            //-------------------------------------------------------------------------------------------//
+            // copy the time series to a location in the same DSS file that has a different native datum //
+            //-------------------------------------------------------------------------------------------//
+            printf("==> %s:%s (v%d)\n", filename[SRC], tsPathname[DST], dstDssVer);
+            status = zcopyRecord(ifltab[SRC], ifltab[SRC], tsPathname[SRC], tsPathname[DST]);
+            assert(status == STATUS_OKAY);
+            //-------------------------------------------------------//
+            // retrieve the copied time series and verify the values //
+            //-------------------------------------------------------//
+            tss = zstructTsNewTimes(
+                tsPathname[DST],
+                startDate,
+                startTime,
+                endDate,
+                endTime);
+            assert(tss != NULL);
+            status = ztsRetrieve(
+                ifltab[SRC], // file table
+                tss,         // time series struct
+                0,           // retrieve flag (0=adhere to time window and [for reg] create times array)
+                0,           // retrieve doubles flag (0=as stored, 1=floats, 2=doubles)
+                1);          // retrieve quality flag (0/1)
+            assert(status == STATUS_OKAY);
+            for (int i = 0; i < numberTsValues; ++i) {
+                assert(fabs(tss->doubleValues[i] - tsValues[SRC][i]) < FLT_EPSILON);
+            }
+            //-------------------------------------------------------------------------------------------//
+            // copy the paired data to a location in the same DSS file that has a different native datum //
+            //-------------------------------------------------------------------------------------------//
+            printf("==> %s:%s (v%d)\n", filename[SRC], pdPathname[DST], dstDssVer);
+            status = zcopyRecord(ifltab[SRC], ifltab[SRC], pdPathname[SRC], pdPathname[DST]);
+            assert(status == STATUS_OKAY);
+            //-------------------------------------------------------//
+            // retrieve the copied paired data and verify the values //
+            //-------------------------------------------------------//
+            pds = zstructPdNew(pdPathname[DST]);
+            assert(pds != NULL);
+            status = zpdRetrieve(ifltab[SRC], pds, 0);
+            assert(status == STATUS_OKAY);
+            for (int i = 0; i < numberPdOrdinates; ++i) {
+                assert(fabs(pds->doubleValues[i] - pdValues[SRC][i]) < FLT_EPSILON);
+            }
+            //------------------------------------------------------------------------------------------//
+            // copy the time series to a location in another DSS file that has a different native datum //
+            //------------------------------------------------------------------------------------------//
+            printf("==> %s:%s (v%d)\n", filename[DST], tsPathname[DST], dstDssVer);
+            status = zcopyRecord(ifltab[SRC], ifltab[DST], tsPathname[SRC], tsPathname[DST]);
+            assert(status == STATUS_OKAY);
+            //-------------------------------------------------------//
+            // retrieve the copied time series and verify the values //
+            //-------------------------------------------------------//
+            tss = zstructTsNewTimes(
+                tsPathname[DST],
+                startDate,
+                startTime,
+                endDate,
+                endTime);
+            assert(tss != NULL);
+            status = ztsRetrieve(
+                ifltab[DST], // file table
+                tss,         // time series struct
+                0,           // retrieve flag (0=adhere to time window and [for reg] create times array)
+                0,           // retrieve doubles flag (0=as stored, 1=floats, 2=doubles)
+                1);          // retrieve quality flag (0/1)
+            assert(status == STATUS_OKAY);
+            for (int i = 0; i < numberTsValues; ++i) {
+                assert(fabs(tss->doubleValues[i] - tsValues[SRC][i]) < FLT_EPSILON);
+            }
+            //------------------------------------------------------------------------------------------//
+            // copy the paired data to a location in another DSS file that has a different native datum //
+            //------------------------------------------------------------------------------------------//
+            printf("==> %s:%s (v%d)\n", filename[DST], pdPathname[DST], dstDssVer);
+            status = zcopyRecord(ifltab[SRC], ifltab[DST], pdPathname[SRC], pdPathname[DST]);
+            assert(status == STATUS_OKAY);
+            //-------------------------------------------------------//
+            // retrieve the copied paired data and verify the values //
+            //-------------------------------------------------------//
+            pds = zstructPdNew(pdPathname[DST]);
+            assert(pds != NULL);
+            status = zpdRetrieve(ifltab[DST], pds, 0);
+            assert(status == STATUS_OKAY);
+            for (int i = 0; i < numberPdOrdinates; ++i) {
+                assert(fabs(pds->doubleValues[i] - pdValues[SRC][i]) < FLT_EPSILON);
+            }
+            zclose(ifltab[SRC]);
+            zclose(ifltab[DST]);
+        }
+    }
+    remove(filename[SRC]);
+    remove(filename[DST]);
+}
+
+void testCopyRecordWithVdi() {
+    testCopyRecordWithVdi_NoVdiInDestination();
+    testCopyRecordWithVdi_OtherNativeDatumInDestination();
+    testCopyRecordWithVdi_SameNativeDatumInDestination();
+}
+

--- a/test/Dss-C/source/testVerticalDatum_c.c
+++ b/test/Dss-C/source/testVerticalDatum_c.c
@@ -2121,7 +2121,7 @@ void testStoreRetrievePairedData() {
     }
     printf("\n\n%5d Paired data tests passed\n\n\n", count);
 }
-void retrieveAndCompareVdi(long long ifltab, const char* pathname, const void *sourceData) {
+void retrieveAndCompareVdi(long long *ifltab, const char* pathname, const void *sourceData) {
     zStructTimeSeries* tss[2];
     memset(tss, 0, sizeof(tss));
     zStructPairedData* pds[2];

--- a/test/Dss-C/source/testVerticalDatum_c.c
+++ b/test/Dss-C/source/testVerticalDatum_c.c
@@ -2519,7 +2519,7 @@ void testCopyRecordWithVdi_NoVdiInDestination() {
                 //------------------------------------------------------------------------//
                 zdelete(ifltab[DST], tsPathname[DST]);
                 deleteLocationRecord(ifltab[DST], tsPathname[DST]);
-                status = zcopyRecord(ifltab[SRC], ifltab[DST], tsPathname[DST], tsPathname[DST]);
+                status = zcopyRecord(ifltab[SRC], ifltab[DST], tsPathname[SRC], tsPathname[DST]);
                 assert(status == STATUS_OKAY);
                 //---------------------------//
                 // verify the VDI was copied //

--- a/test/Dss-C/source/testVerticalDatum_c.c
+++ b/test/Dss-C/source/testVerticalDatum_c.c
@@ -2364,8 +2364,8 @@ void testCopyRecordWithVdi_NoVdiInDestination() {
 
         ""
     };
-    int xmlCount = 7;
-    char *xml[xmlCount];
+    const int xmlCount = sizeof(_xml) / sizeof(_xml[0]);
+    char *xml[sizeof(_xml) / sizeof(_xml[0])];
     memset(xml, 0, sizeof(xml));
 
     //-------------------//

--- a/test/Dss-C/source/testVerticalDatum_c.c
+++ b/test/Dss-C/source/testVerticalDatum_c.c
@@ -12,7 +12,7 @@ void testZsetZquery();
 void testStoreRetrieveTimeSeries();
 void testV6TimeSeiresWithMultipleVerticalDatums();
 void testStoreRetrievePairedData();
-void testV7CopyRecordWithVdi();
+void testCopyRecordWithVdi();
 
 const int SRC = 0;
 const int DST = 1;
@@ -27,7 +27,7 @@ int test_vertical_datums_c() {
     //testStoreRetrieveTimeSeries();
     //testV6TimeSeiresWithMultipleVerticalDatums();
     //testStoreRetrievePairedData();
-    testV7CopyRecordWithVdi();
+    testCopyRecordWithVdi();
     return 0;
 }
 void testDelimitedStringOps() {
@@ -2271,7 +2271,7 @@ void retrieveAndCompareVdi(long long *ifltab, const char* pathname, const void *
     }
 }
 
-void testV7CopyRecordWithVdi() {
+void testCopyRecordWithVdi() {
     long long ifltab[2][250] = { 0 };
     int status;
     zStructTimeSeries* tss = NULL;


### PR DESCRIPTION
`zcopyRecord()` now copies VDI to destination if the destination has no VDI
* VDI copied only on when copying time series or paired data records with elevation parameter
  - If destination already has VDI then the storage behaviors listed [here ](https://www.hec.usace.army.mil/confluence/pages/viewpage.action?spaceKey=DSS&title=HEC-DSS+Vertical+Datum+Capabilities)are followed and the copy may or may not succeed
* Fix bugs in `zcopyRecord()` where pathnames weren't set correctly (affected normal store operations but not internal copy)
* v6 to v6 or 7: no code change, just retrieve and store as usual
* v7 to v6:  no code change, just retrieve and store as usual
* v7 to v7: force code to use retrieve/store, which carries VDI, when copying TS or PD with Elev, instead of using  internal copy
* Fix bug when storing to v6 with zStructTimeSeries (`ztsStore()`) or zStructPiaredData (`zpdStore()`):
  - copy VDI from internal location struct to user header before storing (only if no VDI in header - but header may be non-null)
  - restore original header after storing to preserve original structure content after call