### PR TITLE
Bugfix/copy vdi (Again)

### DIFF
--- a/heclib/heclib_c/src/Utilities/verticalDatum.c
+++ b/heclib/heclib_c/src/Utilities/verticalDatum.c
@@ -1997,12 +1997,12 @@ int pathnameIsElevPd(const char* pathname) {
         zpathnameGetPart(pathname, 3, cPart, sizeof(cPart));
         char* saveptr;
         char* cp = strtok_r(cPart, "-", &saveptr);
-        if (cp == NULL || !strncasecmp(cp, "ELEV", 4)) {
+        if (cp != NULL && !strncasecmp(cp, "ELEV", 4)) {
             result += 1;
         }
         if (cp) {
             cp = strtok_r(NULL, "-", &saveptr);
-            if (cp == NULL || !strncasecmp(cp, "ELEV", 4)) {
+            if (cp != NULL && !strncasecmp(cp, "ELEV", 4)) {
                 result += 2;
             }
         }

--- a/heclib/heclib_c/src/Utilities/verticalDatum.c
+++ b/heclib/heclib_c/src/Utilities/verticalDatum.c
@@ -1997,12 +1997,14 @@ int pathnameIsElevPd(const char* pathname) {
         zpathnameGetPart(pathname, 3, cPart, sizeof(cPart));
         char* saveptr;
         char* cp = strtok_r(cPart, "-", &saveptr);
-        if (!strncasecmp(cp, "ELEV", 4)) {
+        if (cp == NULL || !strncasecmp(cp, "ELEV", 4)) {
             result += 1;
         }
-        cp = strtok_r(NULL, "-", &saveptr);
-        if (!strncasecmp(cp, "ELEV", 4)) {
-            result += 2;
+        if (cp) {
+            cp = strtok_r(NULL, "-", &saveptr);
+            if (cp == NULL || !strncasecmp(cp, "ELEV", 4)) {
+                result += 2;
+            }
         }
     }
     return result;

--- a/heclib/heclib_c/src/headers/hecdssInternal.h
+++ b/heclib/heclib_c/src/headers/hecdssInternal.h
@@ -37,7 +37,7 @@
 
 
 #define DSS_VERSION "7-IQ"
-#define DSS_VERSION_DATE "11 January 2023"
+#define DSS_VERSION_DATE "12 January 2023"
 
 
 


### PR DESCRIPTION
Modified so that zcopyRecord() doesn't fail because of incompatible VDI when copying to DSS 6