### PR TITLE
fixes the flakey catalog test

### DIFF
--- a/heclib/heclib_c/src/System/getCurrentTimeMillis.c
+++ b/heclib/heclib_c/src/System/getCurrentTimeMillis.c
@@ -37,12 +37,12 @@ long long getCurrentTimeMillis()
 
 	_ftime64_s( &timebuffer );
 	ltime = (timebuffer.time - (long long)(timebuffer.timezone * SECS_IN_1_MINUTE));
+	ltime *= 1000L;
 	ltime += (long long)timebuffer.millitm;
 	if (timebuffer.dstflag) {
 		//  Only do USA DST (60 minutes)
-		ltime += SECS_IN_1_HOUR;
+		ltime += SECS_IN_1_HOUR * 1000L;
 	}
-	ltime *= 1000L;
 #else
 	struct timespec spec;
 

--- a/heclib/heclib_c/src/headers/hecdssInternal.h
+++ b/heclib/heclib_c/src/headers/hecdssInternal.h
@@ -38,7 +38,7 @@
 
 
 #define DSS_VERSION "7-IS"
-#define DSS_VERSION_DATE "26 Apr 2024"
+#define DSS_VERSION_DATE "30 Apr 2024"
 
 
 

--- a/test/C/CatalogTest.c
+++ b/test/C/CatalogTest.c
@@ -107,13 +107,13 @@ int main(int argc, char* argv[])
 				}
 			}
 			printf("%s\n", pathname);
-		
+		}
 		_close(ihandle);
 		//  _unlink(filename);
 		free(tempname);
 
 		zclose(ifltab);
-	}
+	
 
 	return 0;
 }

--- a/test/Dss-C/Dss-C.vcxproj
+++ b/test/Dss-C/Dss-C.vcxproj
@@ -153,6 +153,7 @@
     <ClCompile Include="source\testLargeCopy.c" />
     <ClCompile Include="source\testNoDates.c" />
     <ClCompile Include="source\testNormalizeFPart.c" />
+    <ClCompile Include="source\current_time_testing.c" />
     <ClCompile Include="source\TestUtility.c" />
     <ClCompile Include="source\SampleTimeSeries3.c" />
     <ClCompile Include="source\testAdHoc.c" />

--- a/test/Dss-C/TestDssC.c
+++ b/test/Dss-C/TestDssC.c
@@ -194,6 +194,10 @@ int runTheTests() {
 	char fileName6[80];
 	int status;
 
+	status = testCatalog();
+	if (status != 0)
+		return status;
+
 	printf("test read without dates\n");
 	status = testNoDates(7);
 	if (status != STATUS_OKAY)

--- a/test/Dss-C/TestDssC.c
+++ b/test/Dss-C/TestDssC.c
@@ -194,7 +194,7 @@ int runTheTests() {
 	char fileName6[80];
 	int status;
 
-	status = testCatalog();
+	status = current_time_testing();
 	if (status != 0)
 		return status;
 

--- a/test/Dss-C/TestDssC.h
+++ b/test/Dss-C/TestDssC.h
@@ -108,5 +108,6 @@ int ImportProfile(const char* csvFilename, const char* dssFilename, const char* 
 	const char* time, const char* units, const char* datatype);
 int read_profile_from_csv(zStructTimeSeries* tss, const char* csvFilename);
 int units_issue_126();
+int current_time_testing();
 
 #endif

--- a/test/Dss-C/source/current_time_testing.c
+++ b/test/Dss-C/source/current_time_testing.c
@@ -1,0 +1,30 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "TestDssC.h"
+
+int current_time_testing() {
+
+  long long t;
+  long long prev_t = getCurrentTimeMillis();
+
+  for (size_t i = 0; i < 500; i++)
+  {
+#ifdef _MSC_VER
+    Sleep(10);
+#else
+    usleep(10 * 1000);
+#endif
+    t = getCurrentTimeMillis(); 
+    //printf("\n %lld", t);
+    if (t < prev_t) {
+      printf("\n... Oops... time going backward... in %s",__FILE__);
+      return -1;
+    }
+
+    prev_t = t;
+    
+
+  }
+  return 0;
+}

--- a/test/Dss-C/source/current_time_testing.c
+++ b/test/Dss-C/source/current_time_testing.c
@@ -13,6 +13,7 @@ int current_time_testing() {
 #ifdef _MSC_VER
     Sleep(10);
 #else
+    #include <unistd.h>
     usleep(10 * 1000);
 #endif
     t = getCurrentTimeMillis(); 

--- a/test/Dss-C/source/testCatalog.c
+++ b/test/Dss-C/source/testCatalog.c
@@ -17,7 +17,6 @@
 
 int testCatalog()
 {
-	int DEBUG=0;
 	int status;
 	int len;
 
@@ -109,25 +108,31 @@ int testCatalog()
 	if (status < 0) {
 		if (zcheckStatus(ifltab, status, 1, "Fail in testCatalog Loc 3, zcatalog status ")) return status; 
 	}
+	printf("\nfound %d records in catalog ", catStruct->numberPathnames);
+
 	zstructFree(catStruct);
 	
 	catStruct = zstructCatalogNew();
 	catStruct->boolIncludeDates = 1;
+	printf("\nreading catlog with dates catStruct->boolIncludeDates = 1");
 	status = zcatalog(ifltab, (const char *)0, catStruct, 1);	
 	if (status < 0) {
 		if (zcheckStatus(ifltab, status, 1, "Fail in testCatalog Loc 4, zcatalog status ")) return status; 
 	}
+	printf("\nfound %d records in catalog ", catStruct->numberPathnames);
 	zstructFree(catStruct);
 
 	//  Now test for wild characters
 	stringCopy(pathWithWild, sizeof(pathWithWild), "//SACRAMENTO/*/*/*/OBS/", _TRUNCATE);
 	catStruct = zstructCatalogNew();
 	catStruct->boolIncludeDates = 1;
+	printf("\nreading catalog with filter '//SACRAMENTO/*/*/*/OBS/' ");
 	status = zcatalog(ifltab, pathWithWild, catStruct, 1);
 	if (status < 0) {
 		zstructFree(catStruct);
 		if (zcheckStatus(ifltab, status, 1, "Fail in testCatalog Loc 6, zcatalog status ")) return status; 
 	}
+	printf("\nfound %d records in catalog ", catStruct->numberPathnames);
 	zstructFree(catStruct);
 
 	//  Now, a catalog file
@@ -135,14 +140,17 @@ int testCatalog()
 	len = (int)strlen(catFilename);
 	catFilename[len-1] = 'c';
 	remove(catFilename);
+	printf("\nwriting catalog to %s ", catFilename);
 	status = zcatalogFile(ifltab, catFilename, 1, (const char *)0);
 	if (status < 0) {
 		if (zcheckStatus(ifltab, status, 1, "Fail in testCatalog Loc 7, zcatalog status ")) return status; 
 	}
-
+	
 	
 	//  Version 6 code on vers 7 file
+	printf("\nreading catalog with legacy(v6) filter  'B=SACRAMENTO, F=OBS' ");
 	stringCopy(pathWithWild, sizeof(pathWithWild), "B=SACRAMENTO, F=OBS", _TRUNCATE);
+	printf("\n%s", pathWithWild);
 	filePos = 0;
 	count = 0;
 	while (filePos >= 0) {
@@ -163,12 +171,15 @@ int testCatalog()
 		
 		//  Test the data CRC function; assume okay if values > 0
 		catStruct = zstructCatalogNew();
+		printf("\nTesting with catStruct->boolGetCRCvalues = 1");
 		catStruct->boolGetCRCvalues = 1;
 		status = zcatalog(ifltab, (const char*)0, catStruct, 0);
+		
 		if (status < 0) {
 			zstructFree(catStruct);
 			if (zcheckStatus(ifltab, status, 1, "Fail in testCatalog Loc 40, zcatalog CRC ")) return status; 
 		}
+		printf("\nfound %d records ", catStruct->numberPathnames);
 		for (i=0; i<catStruct->numberPathnames; i++) {
 			if (catStruct->crcValues[i] < 1) {
 				zstructFree(catStruct);


### PR DESCRIPTION
fixes #234 

The catalog test calls getCurrentTimeMillis to get a reference time,  then the test modifies 10 records which are time-stamped. Correct time-stamps are required to retrieve the 10 modified records since the reference time.

long long getCurrentTimeMillis() -- was incorrectly mixing seconds, hours, and milliseconds.