### PR TITLE
fix for DSS 7 collections.

### DIFF
--- a/heclib/heclib_c/src/Internal/zcatComparePath.c
+++ b/heclib/heclib_c/src/Internal/zcatComparePath.c
@@ -111,7 +111,9 @@ int zcatComparePath(const char *cpath, int *partAction, int *lengths,
 					//  If so, and boolCollection is true, then we are looking for all sequences for this collection
 					//  If both are collections, change the collection sequence to "XXXXXX"
 					//  so that both will match, regardless of the sequqnce
-					if ((lengths[i] > 9) && (strlen(pathPart) > 9)) {
+					//  A minimum length of a F-part for collection is 9 characters
+					//  example: C:123456|
+					if ((lengths[i] >= 9) && (strlen(pathPart) >= 9)) {
 						i1 = toupper(stringToFind[0]);
 						i2 = toupper(pathPart[0]);
 						//  Look for "C:"

--- a/heclib/heclib_c/src/Internal/zcatInternalSort.c
+++ b/heclib/heclib_c/src/Internal/zcatInternalSort.c
@@ -130,7 +130,6 @@ int zcatInternalSort(long long *ifltab, const char *pathWithWild, zStructCatalog
 
 	if (sortedStruct) {
 		nonSortedStruct->boolIncludeDates = sortedStruct->boolIncludeDates;
-		nonSortedStruct->boolIncludeDates = sortedStruct->boolIncludeDates;
 		nonSortedStruct->statusWanted = sortedStruct->statusWanted;
 		nonSortedStruct->typeWantedStart = sortedStruct->typeWantedStart;
 		nonSortedStruct->typeWantedEnd = sortedStruct->typeWantedEnd;

--- a/heclib/heclib_c/src/headers/hecdssInternal.h
+++ b/heclib/heclib_c/src/headers/hecdssInternal.h
@@ -38,7 +38,7 @@
 
 
 #define DSS_VERSION "7-IS"
-#define DSS_VERSION_DATE "30 Apr 2024"
+#define DSS_VERSION_DATE "5 May 2024"
 
 
 


### PR DESCRIPTION
Path comparison for F part was assuming additional F-Part after the pipe '|' exists.  

Testing was done with a Java Junit test.