### PR TITLE
Fix/prevent crash paried data

### DIFF
--- a/heclib/heclib_c/src/headers/hecdssInternal.h
+++ b/heclib/heclib_c/src/headers/hecdssInternal.h
@@ -39,7 +39,7 @@
 
 #define DSS_VERSION "7-IU"
 
-#define DSS_VERSION_DATE "15 January 2025"
+#define DSS_VERSION_DATE "17 January 2025"
 
 
 const char *ztypeName(int recordType, int boolAbbreviation);

--- a/heclib/heclib_c/src/headers/hecdssInternal.h
+++ b/heclib/heclib_c/src/headers/hecdssInternal.h
@@ -39,7 +39,7 @@
 
 #define DSS_VERSION "7-IU"
 
-#define DSS_VERSION_DATE "21 November 2024"
+#define DSS_VERSION_DATE "15 January 2025"
 
 
 const char *ztypeName(int recordType, int boolAbbreviation);

--- a/heclib/heclib_f/src/zspdi6.f
+++ b/heclib/heclib_f/src/zspdi6.f
@@ -503,6 +503,7 @@ C
      *  nuhead_copy2,
      *  size(iuhead_copy2),
      *  errMsg)
+      iplan_write = 0
       IF (LDOUBLE) THEN
          JTYPE = 205
          N = NVALS * 2
@@ -510,14 +511,14 @@ C        Swap words on unix to keep compatitable with PC
          IF (IFLTAB(KDSWAP).NE.0) CALL zdswap6(DVALUES, N)
          CALL zwritex6 (IFLTAB, CPATH, NPATH, IGBUFF, NIHEAD,
      *   ICHEAD, 0, iuhead_copy2, nuhead_copy2, DVALUES, N, JTYPE,
-     *   IPLAN, ISTAT, LFOUND)
+     *   iplan_write, ISTAT, LFOUND)
 C        Swap back so we don't mess up the user's data
          IF (IFLTAB(KDSWAP).NE.0) CALL zdswap6(DVALUES, N)
       ELSE
          JTYPE = 200
          CALL zwritex6 (IFLTAB, CPATH, NPATH, IGBUFF, NIHEAD,
      *   ICHEAD, 0, iuhead_copy2, nuhead_copy2, SVALUES, NVALS,
-     *   JTYPE, IPLAN, ISTAT, LFOUND)
+     *   JTYPE, iplan_write, ISTAT, LFOUND)
       ENDIF
 C
 

--- a/heclib/heclib_f/src/zspdi6.f
+++ b/heclib/heclib_f/src/zspdi6.f
@@ -504,6 +504,10 @@ C
      *  size(iuhead_copy2),
      *  errMsg)
       iplan_write = 0
+C     IPLAN = 0   Always write
+C     IPLAN = 1   Only write if new record
+C     IPLAN = 2   Only write if old record
+      
       IF (LDOUBLE) THEN
          JTYPE = 205
          N = NVALS * 2

--- a/heclib/javaHeclib/src/Hec_zspdd.c
+++ b/heclib/javaHeclib/src/Hec_zspdd.c
@@ -48,6 +48,31 @@ JNIEXPORT void JNICALL Java_hec_heclib_util_Heclib_Hec_1zspdd
     nord     = (int) j_nord;
     ncurve   = (int) j_ncurve;
     ihorz    = (int) j_ihorz;
+		istat = (*env)->GetIntArrayElements(env, j_istat, 0);
+
+		if (zmessageLevel((long long*)ifltab, MESS_METHOD_JNI_ID, MESS_LEVEL_INTERNAL_DIAG_1)) {
+			zmessageDebug((long long*)ifltab, DSS_FUNCTION_javaNativeInterface_ID, "Enter Heclib_Hec_zspdd, pathname: ", pathname);
+		}
+
+		//  Initial error checking....
+		if ((nord <= 0) || (ncurve <= 0)
+			|| j_c1unit == 0
+			|| j_c1type == 0
+			|| j_c2unit == 0
+			|| j_c2type == 0
+
+			) {
+			if (zmessageLevel((long long*)ifltab, MESS_METHOD_WRITE_ID, MESS_LEVEL_TERSE)) {
+				zmessage2((long long*)ifltab, "Heclib_Hec_zspdd: No data; or null units or type. Can't store empty record.  Pathname: ", pathname);
+			}
+			istat[0] = -1;
+			(*env)->ReleaseIntArrayElements(env, j_ifltab, ifltab, 0);
+			(*env)->ReleaseStringUTFChars(env, j_pathname, pathname);
+			(*env)->ReleaseIntArrayElements(env, j_istat, istat, 0);
+			return;
+		}
+
+
     c1unit   = (*env)->GetStringUTFChars (env, j_c1unit, 0);
     c1type   = (*env)->GetStringUTFChars (env, j_c1type, 0);
     c2unit   = (*env)->GetStringUTFChars (env, j_c2unit, 0);
@@ -57,7 +82,7 @@ JNIEXPORT void JNICALL Java_hec_heclib_util_Heclib_Hec_1zspdd
     nheadu   = (int) j_nheadu;
     if(nheadu) headu = (*env)->GetIntArrayElements (env, j_headu, 0);
     iplan    = (int) j_iplan;
-    istat    = (*env)->GetIntArrayElements (env, j_istat, 0);
+    
 
 
 	if (zmessageLevel((long long*)ifltab, MESS_METHOD_JNI_ID, MESS_LEVEL_INTERNAL_DIAG_1)) {		


### PR DESCRIPTION
These updates support moving to a default of double instead of floats in the Java libraries using HEC-DSS.