### PR TITLE
drop use of intel portability option

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -45,7 +45,7 @@ jobs:
 
       # Save some artifacts
       - name: upload-artifacts hecdss.dll and javaHeclib.dll
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dss
           path: |

--- a/build.bat
+++ b/build.bat
@@ -13,8 +13,13 @@ echo %build_number%
 dssVersion.exe heclib\heclib_c\src\headers\hecdssInternal.h %build_number% > heclib\javaheclib\version_build.h
 
 cd heclib\heclib_f
-nmake -f Makefile.win  DEBUG=1 clean all
-nmake -f Makefile.win  clean all
+:: debug
+nmake -f Makefile.win  DEBUG=1 clean
+nmake -f Makefile.win  DEBUG=1 
+
+:: release
+nmake -f Makefile.win  clean
+nmake -f Makefile.win  
 
 cd %~dp0
 msbuild dss.sln /p:Configuration=Release /p:Platform=x64

--- a/heclib/heclib_f/Makefile.win
+++ b/heclib/heclib_f/Makefile.win
@@ -21,9 +21,7 @@ TARGET=$(OUT_DIR)\heclib_f.lib
 
 FFLAGS=/nologo /debug:$(D_LEVEL) /MP /Od /fpp /I"src\headers" /reentrancy:threaded /warn:noalignments \
  /Qsave /Qinit:zero /names:lowercase /iface:cref /assume:underscore  /traceback \
-  /check:all /libs:static $(DLIB) /threads /4Yportlib /c /object:$(OUT_DIR)\ 
-
-all: $(TARGET)
+  /check:all /libs:static $(DLIB) /threads /c /object:$(OUT_DIR)\ 
 
 $(OUT_DIR)\heclib_f.lib: 
 	echo $(DSS_PLATFORM_DIR)

--- a/heclib/heclib_f/heclib_f.vfproj
+++ b/heclib/heclib_f/heclib_f.vfproj
@@ -28,7 +28,7 @@
 			<Tool Name="VFManifestTool" SuppressStartupBanner="true"/>
 		</Configuration>
 		<Configuration Name="Debug|x64" UseCompiler="ifortCompiler" OutputDirectory="$(ProjectDir)\$(PlatformName)\$(ConfigurationName)" IntermediateDirectory="$(ProjectDir)\$(PlatformName)\$(ConfigurationName)_intermediate" TargetName="heclib_f" ConfigurationType="typeStaticLibrary">
-			<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" MultiProcessorCompilation="true" Optimization="optimizeDisabled" Preprocess="preprocessYes" AdditionalIncludeDirectories="src\headers" ReentrantCode="reentrancyThreaded" WarnUnusedVariables="true" WarnTruncateSource="true" WarnUnalignedData="false" LocalVariableStorage="localStorageSave" LocalSavedScalarsZero="true" ExternalNameInterpretation="extNameLowerCase" CallingConvention="callConventionCRef" ExternalNameUnderscore="true" Traceback="true" RuntimeChecks="rtChecksNone" RuntimeLibrary="rtMultiThreadedDebug" UsePortlib="true"/>
+			<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" MultiProcessorCompilation="true" Optimization="optimizeDisabled" Preprocess="preprocessYes" AdditionalIncludeDirectories="src\headers" ReentrantCode="reentrancyThreaded" WarnUnusedVariables="true" WarnTruncateSource="true" WarnUnalignedData="false" LocalVariableStorage="localStorageSave" LocalSavedScalarsZero="true" ExternalNameInterpretation="extNameLowerCase" CallingConvention="callConventionCRef" ExternalNameUnderscore="true" Traceback="true" RuntimeChecks="rtChecksNone" RuntimeLibrary="rtMultiThreadedDebug"/>
 			<Tool Name="VFLinkerTool" SuppressStartupBanner="true"/>
 			<Tool Name="VFLibrarianTool" OutputFile="$(OutDir)\heclib_f$(TargetExt)"/>
 			<Tool Name="VFResourceCompilerTool"/>
@@ -40,7 +40,7 @@
 			<Tool Name="VFManifestTool" SuppressStartupBanner="true"/>
 		</Configuration>
 		<Configuration Name="Release|x64" UseCompiler="ifortCompiler" OutputDirectory="$(ProjectDir)\$(PlatformName)\$(ConfigurationName)" IntermediateDirectory="$(ProjectDir)\$(PlatformName)\$(ConfigurationName)_intermediate" TargetName="heclib_f" ConfigurationType="typeStaticLibrary">
-			<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" MultiProcessorCompilation="true" Optimization="optimizeDisabled" Preprocess="preprocessYes" AdditionalIncludeDirectories="src\headers" ReentrantCode="reentrancyThreaded" WarnUnalignedData="false" LocalVariableStorage="localStorageSave" LocalSavedScalarsZero="true" ExternalNameInterpretation="extNameLowerCase" CallingConvention="callConventionCRef" ExternalNameUnderscore="true" Traceback="true" RuntimeChecks="rtChecksNone" BoundsCheck="true" UsePortlib="true"/>
+			<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" MultiProcessorCompilation="true" Optimization="optimizeDisabled" Preprocess="preprocessYes" AdditionalIncludeDirectories="src\headers" ReentrantCode="reentrancyThreaded" WarnUnalignedData="false" LocalVariableStorage="localStorageSave" LocalSavedScalarsZero="true" ExternalNameInterpretation="extNameLowerCase" CallingConvention="callConventionCRef" ExternalNameUnderscore="true" Traceback="true" RuntimeChecks="rtChecksNone" BoundsCheck="true"/>
 			<Tool Name="VFLibrarianTool" OutputFile="$(OutDir)\heclib_f$(TargetExt)"/>
 			<Tool Name="VFResourceCompilerTool"/>
 			<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>
@@ -404,7 +404,8 @@
 			<File RelativePath=".\src\zsetTimezone.f"/>
 			<File RelativePath=".\src\zsitsc6.f"/>
 			<File RelativePath=".\src\zsitsi6.f"/>
-			<File RelativePath=".\src\zspdi6.f"/>
+			<File RelativePath=".\src\zspdi6.f">
+			</File>
 			<File RelativePath=".\src\zsqprm6.f"/>
 			<File RelativePath=".\src\zsqueeze6.f"/>
 			<File RelativePath=".\src\zsrtpa6.f"/>

--- a/test/Fortran/Dss7-Fortran.vfproj
+++ b/test/Fortran/Dss7-Fortran.vfproj
@@ -5,7 +5,7 @@
 	</Platforms>
 	<Configurations>
 		<Configuration Name="Debug|x64" UseCompiler="ifortCompiler">
-			<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" MultiProcessorCompilation="true" Optimization="optimizeDisabled" Preprocess="preprocessYes" WarnDeclarations="true" WarnUnusedVariables="true" WarnUncalled="true" ExternalNameInterpretation="extNameLowerCase" CallingConvention="callConventionCRef" ExternalNameUnderscore="true" Traceback="true" RuntimeChecks="rtChecksAll" BoundsCheck="true" RuntimeLibrary="rtMultiThreadedDebug" UsePortlib="true"/>
+			<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" MultiProcessorCompilation="true" Optimization="optimizeDisabled" Preprocess="preprocessYes" WarnDeclarations="true" WarnUnusedVariables="true" WarnUncalled="true" ExternalNameInterpretation="extNameLowerCase" CallingConvention="callConventionCRef" ExternalNameUnderscore="true" Traceback="true" RuntimeChecks="rtChecksAll" BoundsCheck="true" RuntimeLibrary="rtMultiThreadedDebug"/>
 			<Tool Name="VFLinkerTool" LinkIncremental="linkIncrementalYes" SuppressStartupBanner="true" AdditionalLibraryDirectories="..\..\heclib\heclib_c\$(PlatformName)\$(ConfigurationName);..\..\heclib\heclib_f\$(PlatformName)\$(ConfigurationName);..\..\lib\$(Platform);%(AdditionalLibraryDirectories)" IgnoreDefaultLibraryNames="libcmt;MSVCRT" GenerateDebugInformation="true" SubSystem="subSystemConsole" AdditionalDependencies="heclib_f.lib heclib_c.lib zlibstatic.lib"/>
 			<Tool Name="VFResourceCompilerTool"/>
 			<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>
@@ -16,7 +16,7 @@
 			<Tool Name="VFManifestTool" SuppressStartupBanner="true"/>
 		</Configuration>
 		<Configuration Name="Release|x64" UseCompiler="ifortCompiler">
-			<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" MultiProcessorCompilation="true" Optimization="optimizeDisabled" Preprocess="preprocessYes" WarnDeclarations="true" WarnUnusedVariables="true" WarnUncalled="true" ExternalNameInterpretation="extNameLowerCase" CallingConvention="callConventionCRef" ExternalNameUnderscore="true" Traceback="true" RuntimeChecks="rtChecksAll" BoundsCheck="true" UsePortlib="true"/>
+			<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" MultiProcessorCompilation="true" Optimization="optimizeDisabled" Preprocess="preprocessYes" WarnDeclarations="true" WarnUnusedVariables="true" WarnUncalled="true" ExternalNameInterpretation="extNameLowerCase" CallingConvention="callConventionCRef" ExternalNameUnderscore="true" Traceback="true" RuntimeChecks="rtChecksAll" BoundsCheck="true"/>
 			<Tool Name="VFLinkerTool" LinkIncremental="linkIncrementalYes" SuppressStartupBanner="true" AdditionalLibraryDirectories="..\..\heclib\heclib_c\$(PlatformName)\$(ConfigurationName);..\..\heclib\heclib_f\$(PlatformName)\$(ConfigurationName);..\..\lib\$(Platform);%(AdditionalLibraryDirectories)" IgnoreDefaultLibraryNames="libcmt" GenerateDebugInformation="true" SubSystem="subSystemConsole" AdditionalDependencies="heclib_f.lib heclib_c.lib zlibstatic.lib"/>
 			<Tool Name="VFResourceCompilerTool"/>
 			<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>

--- a/test/Fortran/build.bat
+++ b/test/Fortran/build.bat
@@ -13,7 +13,7 @@ if NOT EXIST %OUT_DIR% mkdir %OUT_DIR%
 
 ifort /nologo /debug:Full /MP /Od /fpp /I"src\headers" /reentrancy:threaded /warn:noalignments ^
  /Qsave /Qinit:zero /names:lowercase /iface:cref /assume:underscore ^
- /traceback /check:all /libs:static /dbglibs /threads /4Yportlib ^
+ /traceback /check:all /libs:static /dbglibs /threads  ^
  @source.txt /link ^
  /NODEFAULTLIB:libcmt /NODEFAULTLIB:MSVCRT ^
  ..\..\heclib\heclib_c\%OUT_DIR%\heclib_c.lib ^
@@ -30,7 +30,7 @@ if NOT EXIST %OUT_DIR% mkdir %OUT_DIR%
 
 ifort /nologo /debug:full /MP /Od /fpp /I"src\headers" /reentrancy:threaded /warn:noalignments ^
  /Qsave /Qinit:zero /names:lowercase /iface:cref /assume:underscore ^
- /traceback /check:all /libs:static /threads /4Yportlib ^
+ /traceback /check:all /libs:static /threads  ^
  @source.txt /link /NODEFAULTLIB:libcmt  ^
  ..\..\heclib\heclib_c\%OUT_DIR%\heclib_c.lib ^
  ..\..\heclib\heclib_f\%OUT_DIR%\heclib_f.lib ^


### PR DESCRIPTION
Doesn't apper to be necessary anymore.  Perhaps that was needed for the SHEF code that was removed.