### PR TITLE
remove some problematic 'compatibility' code in a deprecated method

### DIFF
--- a/heclib/heclib_c/src/headers/hecdssInternal.h
+++ b/heclib/heclib_c/src/headers/hecdssInternal.h
@@ -39,7 +39,7 @@
 
 #define DSS_VERSION "7-IU"
 
-#define DSS_VERSION_DATE "18 February 2025"
+#define DSS_VERSION_DATE "14 March 2025"
 
 
 const char *ztypeName(int recordType, int boolAbbreviation);

--- a/heclib/javaHeclib/src/Hec_zplist.c
+++ b/heclib/javaHeclib/src/Hec_zplist.c
@@ -47,24 +47,6 @@ JNIEXPORT jint JNICALL Java_hec_heclib_util_Heclib_Hec_1zplist
 	else {
 		zplist7 ((long long*)ifltab, instr, filePos, pathname, &nPathname, &status,
 		        (int)strlen(instr), (int)sizeof(pathname)-1);
-		if (status == 0) {
-			/////////////////////////////////////////////////
-			//  For compatibility purposes only...
-			//  Make pathname uppercase and change "Minute" to "MIN"
-			upperCase(pathname);
-			pos = strstr(pathname, "MINUTE/");
-			if (pos > 0) {
-				path = pathname;
-				pos += 3;
-				jpos = (int)(pos - path);
-				if (jpos > 0) {
-					pathname[jpos] = '\0';
-					pos += 3;
-					//strcat_s(pathname, sizeof(pathname), pos);
-					stringCat(pathname, sizeof(pathname), pos, _TRUNCATE);
-				}
-			}
-		}
 	}
 
 	if (status) {


### PR DESCRIPTION
Additionally, the third argument to stringCat should be the source string, so removing this block.


fixes:  https://discourse.hecdev.net/t/cwms-3-4-script-pulling-dss-pathname-list/3961/3

