### PR TITLE
Fix strcasestr redefinition conflict on Linux in verticalDatum.c

### DIFF
--- a/heclib/heclib_c/src/Utilities/verticalDatum.c
+++ b/heclib/heclib_c/src/Utilities/verticalDatum.c
@@ -39,7 +39,7 @@ const char* meterUnitAliases[] = {"M","METER","METERS","METRE","METRES"};
 const int footUnitAliasCount = sizeof(footUnitAliases) / sizeof(footUnitAliases[0]);
 const int meterUnitAliasCount = sizeof(meterUnitAliases) / sizeof(meterUnitAliases[0]);
 
-#if !defined(__APPLE__) && !defined(__sun__)
+#if !defined(__APPLE__) && !defined(__sun__) && !defined(__linux__)
 const char* strcasestr(const char* haystack, const char* needle) {
     int   haystackLen = strlen(haystack);
     int   needleLen = strlen(needle);


### PR DESCRIPTION
This pull request updates `heclib/heclib_c/src/Utilities/verticalDatum.c` to prevent redefining `strcasestr` on Linux platforms.

Previously, the custom `strcasestr` function was conditionally compiled only if `__APPLE__` or `__sun__` were *not* defined. However, Linux systems also provide `strcasestr` via glibc, causing a redefinition error during compilation.

This PR updates the conditional check to:

```c
#if !defined(__APPLE__) && !defined(__sun__) && !defined(__linux__)
```

to correctly exclude Linux systems from redefining `strcasestr`.

This change fixes compilation errors when building heclib on Linux distributions (e.g., Ubuntu, RHEL, Fedora).

No other code changes are included.
