### PR TITLE
Ensure macOS package uses a top-level 'javaHeclib' dir

### DIFF
--- a/heclib/macOS-patch-javaHeclib.sh
+++ b/heclib/macOS-patch-javaHeclib.sh
@@ -42,7 +42,16 @@ otool -L "$LIB_DIR/libquadmath.0.dylib"
 otool -L "$LIB_DIR/libgcc_s.1.1.dylib"
 
 echo "Zipping javaHeclib..."
-ZIP_PATH="$LIB_DIR/javaHeclib.zip"
+# Create a folder named javaHeclib and move patched libs into it
+ZIP_ROOT="$LIB_DIR/javaHeclib"
+mkdir -p "$ZIP_ROOT"
+cp "$LIB_DIR/libjavaHeclib.dylib" "$ZIP_ROOT"
+cp "$LIB_DIR/libgfortran.5.dylib" "$ZIP_ROOT"
+cp "$LIB_DIR/libquadmath.0.dylib" "$ZIP_ROOT"
+cp "$LIB_DIR/libgcc_s.1.1.dylib" "$ZIP_ROOT"
+# Create the zip with javaHeclib as the top-level folder
 cd "$LIB_DIR"
-zip -r "$ZIP_PATH" ./*
-pwd && ls
+zip -r "javaHeclib.zip" "javaHeclib"
+
+# Show contents for confirmation
+pwd && ls -l


### PR DESCRIPTION
* Create a javaHeclib folder before packaging
* Copy all .dylib files into that folder
* Zip the archive so that 'javaHeclib' is the root dir in the package

Without a top-level 'javaHeclib' directory, when unzipping, the OS will create a directory with the same name as the zip file (e.g. 'javaHeclib-<version>-<platform>' folder), which make organizing it more difficult.

With a top-level 'javaHeclib' directory, when unzipping, the OS will unzip out that directory (e.g. 'javaHeclib', containing the '.dylib' files).