### PR TITLE
Fix last of the known memory leaks (via DSS-C test program) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ test/Dss-C/Output
 heclib-*.tar
 heclib/build.log
 build/**
+heclib/build/**
 heclib/.vs/
 heclib/Win32/
 heclib/heclib_c/Win32/

--- a/heclib/heclib_c/src/Public/zrename.c
+++ b/heclib/heclib_c/src/Public/zrename.c
@@ -141,14 +141,17 @@ int zrename(long long *ifltab, const char* oldPathname, const char* newPathname)
 			status = zpathnameSetPart(tmpPath, MAX_PATHNAME_LENGTH, wierd_fpart, 6);
 			if (status != STATUS_OKAY) {
 				// error
+				free(newPath);
 				return status;
 			}
 			status = zrename(ifltab, oldPathname, tmpPath);
 			if (status != STATUS_OKAY) {
 				// error
+				free(newPath);
 				return status;
 			}
 			status = zrename(ifltab, tmpPath, newPathname);
+			free(newPath);
 			return status;
 		}
 	}
@@ -217,6 +220,12 @@ int zrename(long long *ifltab, const char* oldPathname, const char* newPathname)
 		end = positions[6];
 		len = (int)strlen(newPathname) + 12;
 		newPath = calloc(len, 1);
+		if (!newPath) {
+			return zerrorProcessing(ifltab, DSS_FUNCTION_zrename_ID,
+				zdssErrorCodes.CANNOT_ALLOCATE_MEMORY, 0, 0,
+				zdssErrorSeverity.MEMORY_ERROR,
+				newPathname, "Allocating space for modified pathname");
+		}
 		stringCopy(newPath, len, newPathname, positions[3]);
 		zpathnamePartPositions(oldPathname, strlen(oldPathname), positions, 7);
 		stringCat(newPath, len, &oldPathname[positions[3]], (positions[5] - positions[3]));

--- a/test/Dss-C/TestDssC.c
+++ b/test/Dss-C/TestDssC.c
@@ -1600,6 +1600,7 @@ int testTsStoreRules() {
 					}
 					assert(tss->doubleValues[j] == expectedValues[j]);
 				}
+				zstructFree(tss);
 			}
 			free(oldValues);
 			free(newValues);

--- a/test/Dss-C/TestDssC.c
+++ b/test/Dss-C/TestDssC.c
@@ -1832,7 +1832,7 @@ int renameTest() {
 	const char* name1 = "//ATWOOD/FLOW-CUMULATIVE/01Sep2024/1Hour/backup/";
 	const char* name2 = "//ATWOOD/FLOW-CUMULATIVE/01Sep2024/1Hour/Backup/";
 
-	long long ifltab[250];
+	long long ifltab[250] = {0};
 	const char* dssFilename = "temp-dss-issue-206.dss";
 	deleteFile(dssFilename);
 
@@ -1966,7 +1966,7 @@ int test_data_shift_during_save(int regular) {
 
 	zStructTimeSeries* markTwain = create_test_data_mark_twain(pathname, regular);
 
-	long long ifltab[250];
+	long long ifltab[250] = {0};
 	const char* dssFilename = "working_mark_twain.dss";
 	deleteFile(dssFilename);
 

--- a/test/Dss-C/TestDssC.c
+++ b/test/Dss-C/TestDssC.c
@@ -1938,6 +1938,7 @@ zStructTimeSeries* create_test_data_mark_twain(const char* pathname, int regular
 	zStructTimeSeries* tss;
 	if (regular) {
 		tss = zstructTsNewRegDoubles(pathname, doubleValues, size, startDate, startTime, units, type);
+		tss->allocated[zSTRUCT_TS_doubleValues] = 1;
 	}
 	else
 	{
@@ -1948,6 +1949,7 @@ zStructTimeSeries* create_test_data_mark_twain(const char* pathname, int regular
 			times[i] = i * 60 + julian;
 		}
 		tss = zstructTsNewIrregDoubles(pathname, doubleValues, size, times, 60, startDate, units, type);
+		tss->allocated[zSTRUCT_TS_doubleValues] = 1;
 		tss->allocated[zSTRUCT_TS_times] = 1;
 	}
 	return tss;
@@ -1999,6 +2001,7 @@ int test_data_shift_during_save(int regular) {
 	zstructFree(tss);
 	zstructFree(tssWrite);
 	zstructFree(tssRead);
+	zstructFree(markTwain);
 	zclose(ifltab);
 	printf("Status = %d in test_data_shift_during_save",status);
 	return status;

--- a/test/Dss-C/TestDssC.c
+++ b/test/Dss-C/TestDssC.c
@@ -1403,6 +1403,7 @@ int testTsStoreRules() {
 	double* expctedIrr0 = (double*)calloc(numData, sizeof(double));
 	double* expctedIrr1 = (double*)calloc(numData, sizeof(double));
 	int i = 0;
+	free(dataCopy);
 	dataCopy = strdup(data);
 	line = strtok_r(dataCopy, "\n", &saveptr1);
 	while (line) {
@@ -1807,6 +1808,7 @@ int testTsStoreRules() {
 	free(expctedReg4);
 	free(expctedIrr0);
 	free(expctedIrr1);
+	free(dataCopy);
 	return status;
 }
 

--- a/test/Dss-C/source/mixed_record_types.c
+++ b/test/Dss-C/source/mixed_record_types.c
@@ -46,7 +46,9 @@ int check_values_compare(long long ifltab[], const char* path, int irregular) {
 
 	if (tss->numberValues != NUM_TS_VALUES) {
 		printf("Expected  %d numberValues, found %d \n", NUM_TS_VALUES, tss->numberValues);
+		zstructFree(tss);
 		rval = -1;
+		return rval;
 	}
 	for (size_t i = 0; i < NUM_TS_VALUES; i++)
 	{
@@ -72,6 +74,7 @@ int check_values_compare(long long ifltab[], const char* path, int irregular) {
 			rval = -2;
 		}
 	}
+	zstructFree(tss);
 	return rval;
 }
 

--- a/test/Dss-C/source/mixed_record_types.c
+++ b/test/Dss-C/source/mixed_record_types.c
@@ -145,7 +145,7 @@ int write_ts_mixed(long long* ifltab, char* path, int writeDoublesFirst) {
 
 int test_mixed_record_types() {
 
-	long long ifltab[250];
+	long long ifltab[250] = {0};
 	const char* dssFileName = "test_create_mixed_record_types.dss";
 	deleteFile(dssFileName);
 

--- a/test/Dss-C/source/testNoDates.c
+++ b/test/Dss-C/source/testNoDates.c
@@ -6,7 +6,7 @@ int testNoDates(int version)
 	char* dssFileName = "test_no_dates_12_values.dss";
 	deleteFile(dssFileName);
 
-	long long ifltab[250];
+	long long ifltab[250] = {0};
 	
 	int	status = hec_dss_zopen(ifltab, dssFileName);
 

--- a/test/Dss-C/source/testText.c
+++ b/test/Dss-C/source/testText.c
@@ -23,6 +23,7 @@ int writeText(const char* filename, const char* path, char* text) {
   }
 
   zstructFree(t);
+  zclose(ifltab);
   return status;
 
 }

--- a/test/Dss-C/test_logging.c
+++ b/test/Dss-C/test_logging.c
@@ -8,7 +8,7 @@
 int test_logging() {
 
 	// log without ifltab reference.
-	long long ifltab[250];
+	long long ifltab[250] = {0};
 	const char* logFilename = "test_log{101}.txt";
 	deleteFile(logFilename);
 


### PR DESCRIPTION
-- Curent valgrind output --


```bash
==114430== HEAP SUMMARY:
==114430==     in use at exit: 0 bytes in 0 blocks
==114430==   total heap usage: 1,307,994 allocs, 1,307,994 frees, 56,630,275,528 bytes allocated
==114430== 
==114430== All heap blocks were freed -- no leaks are possible
==114430== 
==114430== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
karl@a:~/hec-dss/build/test/Dss-C/test$ 
```

Note:    Valgrind isn't testing the JNI code.