### PR TITLE
Make libhecdss self-contained: static zlib + static MSVC runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required(VERSION 3.16)
 project(heclib LANGUAGES C)
 
+# Statically link the MSVC runtime so the shipped DLL needs no VC++ redistributable
+# (VCRUNTIME140.dll); CMP0091 (NEW under the 3.16 minimum) applies it to every target.
 if(MSVC)
-    set(CMAKE_EXE_LINKER_FLAGS /NODEFAULTLIB:MSVCRTD,LIBCMT)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 endif()
 
 function(heclib_set_compile_options target)
@@ -22,12 +24,23 @@ add_subdirectory(deps)
 add_subdirectory(heclib)
 
 find_package(Git QUIET)
+
+# Testing is always enabled so this check runs on every build, even without the optional
+# DSS test-data repo -- it needs only the built lib:
+#   self_contained -- the shipped native links nothing outside the OS baseline, so a
+#   regression to a shared zlib / VC++ runtime, or the macOS @rpath load failure, fails
+#   the build.
+enable_testing()
+add_test(
+    NAME self_contained
+    COMMAND ${CMAKE_COMMAND} -DLIB=$<TARGET_FILE:hecdss>
+            -P ${CMAKE_SOURCE_DIR}/cmake/verify_self_contained.cmake
+)
 if(DSS_TEST_DATA_DIR)
-    option(RUN_TESTS "Run Tests, requires dss-test-data git repo." ON)
+    option(RUN_TESTS "Run functional tests, requires dss-test-data git repo." ON)
     if(RUN_TESTS)
-        enable_testing()
         add_subdirectory(test)
     endif()
 else()
-    message(STATUS "Dss Test Data could not be retrieved.")
+    message(STATUS "Dss Test Data could not be retrieved -- functional tests skipped.")
 endif()

--- a/README.md
+++ b/README.md
@@ -15,13 +15,17 @@ Branches and versions
 
 Windows Dependencies
 
-heclib.dll 
-    libifcoremdd.dll
-    libifportMD.dll
-    libmmdd.dll
-    KERNEL32.dll
-    VCRUNTIME140D.dll
-    ucrtbased.dll
+This source tree builds two Windows natives:
+
+    hecdss.dll      C API native
+    javaHeclib.dll  JNI native loaded by the JVM
+
+Both are self-contained -- zlib and the MSVC runtime are linked statically, so
+neither needs a VC++ redistributable (no VCRUNTIME140.dll) nor any Fortran
+runtime. Each depends only on libraries Windows always provides: KERNEL32.dll
+and the Windows API-set DLLs (api-ms-* / ext-ms-*). The `self_contained` test
+fails the build if the C-API native ever links anything outside that OS
+baseline.
 
 
 

--- a/cmake/verify_self_contained.cmake
+++ b/cmake/verify_self_contained.cmake
@@ -1,0 +1,35 @@
+# Fail if the native at -DLIB links anything outside the OS baseline.
+# Run as: cmake -DLIB=<path-to-native> -P verify_self_contained.cmake
+#
+# file(GET_RUNTIME_DEPENDENCIES) resolves the runtime deps; we exclude the OS system
+# directories and re-flag the libraries we static-link, so a shared zlib / VC++ runtime
+# regression or the macOS @rpath load failure still fails the build.
+cmake_minimum_required(VERSION 3.16)
+
+if(NOT DEFINED LIB)
+    message(FATAL_ERROR "usage: cmake -DLIB=<path-to-native> -P verify_self_contained.cmake")
+endif()
+
+# Windows API-set DLLs are virtual forwarders with no file on disk, so the
+# directory-based POST_EXCLUDE can't reach them; drop them before resolution.
+if(WIN32)
+    set(_win_api_set_excludes PRE_EXCLUDE_REGEXES "^api-ms-" "^ext-ms-")
+endif()
+
+file(GET_RUNTIME_DEPENDENCIES
+    LIBRARIES "${LIB}"
+    RESOLVED_DEPENDENCIES_VAR resolved
+    UNRESOLVED_DEPENDENCIES_VAR unresolved
+    ${_win_api_set_excludes}
+    # Re-flag libraries we static-link, so a regression to a shared one is still caught.
+    POST_INCLUDE_REGEXES ".*/libz\\." ".*[Vv][Cc][Rr][Uu][Nn][Tt][Ii][Mm][Ee].*" ".*[Mm][Ss][Vv][Cc][Pp].*"
+    # Everything else the OS provides lives in these directories.
+    POST_EXCLUDE_REGEXES "^/lib" "^/usr/lib" "^/System/Library" "[Ss]ystem32"
+)
+
+message(STATUS "resolved (non-OS, would need bundling): ${resolved}")
+message(STATUS "unresolved (cannot load off build box): ${unresolved}")
+if(resolved OR unresolved)
+    message(FATAL_ERROR "Native is not self-contained -- links non-OS libraries.")
+endif()
+message(STATUS "PASS: native links only OS-baseline libraries")

--- a/deps/zlib/CMakeLists.txt
+++ b/deps/zlib/CMakeLists.txt
@@ -1,3 +1,7 @@
 FetchContent_MakeAvailable(zlib)
-target_include_directories(zlib PUBLIC ${zlib_SOURCE_DIR} ${zlib_BINARY_DIR})
-add_library(ZLIB::ZLIBSTATIC ALIAS zlib)
+# Bundle zlib statically (madler/zlib: `zlib` is shared, `zlibstatic` static) so the
+# shipped libhecdss doesn't depend on @rpath/libz.1.dylib, which fails to resolve off
+# the build machine on macOS. PIC lets the archive link into the shared lib on Linux.
+set_target_properties(zlibstatic PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_include_directories(zlibstatic PUBLIC ${zlib_SOURCE_DIR} ${zlib_BINARY_DIR})
+add_library(ZLIB::ZLIBSTATIC ALIAS zlibstatic)


### PR DESCRIPTION
## Problem

The published natives aren't self-contained:

| Platform | Non-OS dependency | Result |
|---|---|---|
| **macOS** | `@rpath/libz.1.dylib`, rpath = build-box path only | **fails to load anywhere but the build runner** |
| **Linux** | `libz.so.1` | works only because the system ships zlib |
| **Windows** | `VCRUNTIME140.dll` (VC++ redistributable) | works only where the redistributable is installed |

The macOS case is an outright bug: the shipped `darwin-*` dylib records `@rpath/libz.1.dylib` with the only `LC_RPATH` pointing at the build runner's path, which exists nowhere else, so `dyld` can't resolve zlib and the load fails. CI never caught it because `ctest` ran in the same build tree where that rpath still resolves.

**Root cause:** `deps/zlib/CMakeLists.txt` aliased the static-named `ZLIB::ZLIBSTATIC` to madler/zlib's **shared** `zlib` target (the static one is `zlibstatic`). `heclib_c` links that alias on every non-MSVC platform, so Linux/macOS linked **shared** zlib.

## Changes

1. **Static zlib on all platforms** — repoint `ZLIB::ZLIBSTATIC` at `zlibstatic` (with its includes) and mark it position-independent so the archive links into the shared `libhecdss` on Linux/ELF.
2. **Static MSVC runtime** — `CMAKE_MSVC_RUNTIME_LIBRARY` MultiThreaded, so the Windows DLL no longer needs `VCRUNTIME140.dll`.
3. **Regression guard** — a `self_contained` ctest runs CMake's built-in `file(GET_RUNTIME_DEPENDENCIES)` on the built native and fails if it links anything outside the OS baseline. It needs only the built lib, so testing is now enabled unconditionally (no DSS test-data required).

## Scope

This is the **bug fix + its regression test**, split out for a fast review. The CI/Release/packaging rework and the consumer/JNI API tests follow in a stacked PR (`ci/release-build-package-and-api-tests`).