### PR TITLE
Build/test/package Release in CI; add consumer + JNI API tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,37 +7,75 @@ on:
   workflow_dispatch:
 
 jobs:
-  
+
   build:
+    name: ${{matrix.classifier}}
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-15, windows-latest]
-        jdk: [11]
+        # GitHub macOS runners are all arm64: darwin-aarch64 builds + tests natively;
+        # darwin-x86_64 is cross-built and its x86_64 tests run under Rosetta 2 (with an
+        # x64 JVM, also under Rosetta) so the published binary is functionally exercised,
+        # not just statically checked. classifier mirrors the published native naming.
+        include:
+          - {platform: ubuntu-latest,  classifier: linux-x86_64,   java_arch: x64}
+          - {platform: windows-latest, classifier: win-x86_64,     java_arch: x64}
+          - {platform: macos-15,       classifier: darwin-aarch64, java_arch: aarch64, cmake_args: "-DCMAKE_OSX_ARCHITECTURES=arm64"}
+          - {platform: macos-15,       classifier: darwin-x86_64,  java_arch: x64,     cmake_args: "-DCMAKE_OSX_ARCHITECTURES=x86_64"}
     runs-on: ${{matrix.platform}}
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Checkout test data
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: HydrologicEngineeringCenter/dss-test-data
           path: dss-test-data
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
-          java-version: '${{matrix.jdk}}'
+          distribution: 'temurin'
+          java-version: '11'
+          architecture: ${{matrix.java_arch}}
       - name: Install Valgrind (Ubuntu)
         if: ${{matrix.platform == 'ubuntu-latest'}}
         run: sudo apt-get install -y valgrind
+      # Cross-built x86_64 binaries (and the x64 JVM) run on the arm64 runner via Rosetta.
+      - name: Install Rosetta (macOS x86_64)
+        if: ${{matrix.classifier == 'darwin-x86_64'}}
+        run: softwareupdate --install-rosetta --agree-to-license
+      # Release is the configuration that ships. Pass the classifier so the package name
+      # records the platform.
       - name: Configure
-        run: cmake -B build
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DHECDSS_PACKAGE_CLASSIFIER=${{matrix.classifier}} ${{matrix.cmake_args}}
       - name: Build
-        run: cmake --build build
+        run: cmake --build build --config Release
+      - name: Put dumpbin on PATH (Windows)
+        if: ${{matrix.platform == 'windows-latest'}}
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vs = & $vswhere -latest -property installationPath
+          $dumpbin = Get-ChildItem "$vs\VC\Tools\MSVC\*\bin\Hostx64\x64\dumpbin.exe" | Select-Object -First 1
+          if (-not $dumpbin) { throw "dumpbin.exe not found under $vs" }
+          Add-Content -Path $env:GITHUB_PATH -Value $dumpbin.DirectoryName
       - name: test
-        run: ctest --test-dir build -C Debug
+        run: ctest --test-dir build -C Release --output-on-failure
       - name: Run Valgrind Memory Check
         if: ${{matrix.platform == 'ubuntu-latest'}}
         run: cd ${{github.workspace}}/build/test/Dss-C/test && valgrind --error-exitcode=1 --leak-check=full ../Dss-C test
-
+      # Package from the same gated build -- the published zip is the tested binary.
+      - name: Package native
+        run: cpack --config build/CPackConfig.cmake -C Release -B build
+      - name: Upload native package
+        uses: actions/upload-artifact@v4
+        with:
+          name: hecdss-${{matrix.classifier}}
+          path: build/hecdss-*.zip
+          if-no-files-found: error
+      # Separate artifact: the JNI native a JVM loads (built because the JDK above is present).
+      - name: Upload JNI package
+        uses: actions/upload-artifact@v4
+        with:
+          name: javaHeclib-${{matrix.classifier}}
+          path: build/javaHeclib-*.zip
+          if-no-files-found: error

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,22 +20,27 @@ function(heclib_set_compile_options target)
 endfunction()
 
 find_package(JNI QUIET)
+find_package(Java COMPONENTS Development QUIET)  # javac/java for the JNI load test
 add_subdirectory(deps)
 add_subdirectory(heclib)
 
 find_package(Git QUIET)
 
-# Testing is always enabled so this check runs on every build, even without the optional
-# DSS test-data repo -- it needs only the built lib:
-#   self_contained -- the shipped native links nothing outside the OS baseline, so a
-#   regression to a shared zlib / VC++ runtime, or the macOS @rpath load failure, fails
-#   the build.
+# Testing is always enabled so these checks run on every build, even without the
+# optional DSS test-data repo -- they need only the built lib:
+#   self_contained -- the shipped native links nothing outside the OS baseline.
+#   consume_hecdss -- the shipped native is usable through its public C API/ABI.
 enable_testing()
 add_test(
     NAME self_contained
     COMMAND ${CMAKE_COMMAND} -DLIB=$<TARGET_FILE:hecdss>
             -P ${CMAKE_SOURCE_DIR}/cmake/verify_self_contained.cmake
 )
+add_subdirectory(test/consumer)
+# javaHeclib only exists when a JDK was found; the load test also needs javac/java.
+if(TARGET javaHeclib AND Java_Development_FOUND)
+    add_subdirectory(test/jni)
+endif()
 if(DSS_TEST_DATA_DIR)
     option(RUN_TESTS "Run functional tests, requires dss-test-data git repo." ON)
     if(RUN_TESTS)
@@ -44,3 +49,34 @@ if(DSS_TEST_DATA_DIR)
 else()
     message(STATUS "Dss Test Data could not be retrieved -- functional tests skipped.")
 endif()
+
+# Package the natives from this build, so the published zips are the exact binaries CI
+# built and verified -- not separately produced ones. Two components -> two zips:
+#   capi -- the hecdss C API (dll/so/dylib + header + Windows import lib)
+#   jni  -- the javaHeclib JNI native a JVM loads (built only when a JDK is present)
+# The bare DESTINATION form covers all artifact kinds (RUNTIME .dll / LIBRARY .so/.dylib
+# / ARCHIVE .lib) under one component. The Windows import lib (hecdss.lib) matters: the
+# header exports symbols with __declspec(dllimport), so a consumer can't link without it.
+install(TARGETS hecdss DESTINATION . COMPONENT capi)
+install(FILES heclib/hecdss/hecdss.h DESTINATION . COMPONENT capi)
+if(TARGET javaHeclib)
+    install(TARGETS javaHeclib DESTINATION . COMPONENT jni)
+endif()
+
+# Name the published zip after its platform so an artifact is self-identifying once
+# detached from CI. Classifier (e.g. darwin-aarch64) is passed by CI; falls back to
+# CMake's own arch/system names for a plain local build.
+if(NOT HECDSS_PACKAGE_CLASSIFIER)
+    set(HECDSS_PACKAGE_CLASSIFIER "${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")
+endif()
+
+set(CPACK_GENERATOR "ZIP")
+set(CPACK_ARCHIVE_COMPONENT_INSTALL ON)        # one zip per component, not one combined
+set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY OFF)      # contents at the zip root
+set(CPACK_COMPONENTS_ALL capi)
+set(CPACK_ARCHIVE_CAPI_FILE_NAME "hecdss-${HECDSS_PACKAGE_CLASSIFIER}")
+if(TARGET javaHeclib)
+    list(APPEND CPACK_COMPONENTS_ALL jni)
+    set(CPACK_ARCHIVE_JNI_FILE_NAME "javaHeclib-${HECDSS_PACKAGE_CLASSIFIER}")
+endif()
+include(CPack)

--- a/deps/zlib/CMakeLists.txt
+++ b/deps/zlib/CMakeLists.txt
@@ -1,3 +1,5 @@
+# Statically linked, so drop zlib's own install rules (keeps libz out of the package).
+set(SKIP_INSTALL_ALL ON)
 FetchContent_MakeAvailable(zlib)
 # Bundle zlib statically (madler/zlib: `zlib` is shared, `zlibstatic` static) so the
 # shipped libhecdss doesn't depend on @rpath/libz.1.dylib, which fails to resolve off

--- a/test/consumer/CMakeLists.txt
+++ b/test/consumer/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Smoke-test libhecdss through its public boundary: link the SHARED hecdss target (so
+# the Windows import library, symbol visibility, and runtime load are all exercised)
+# and call the exported API. Unlike the heclib tests, this consumes what we ship.
+# Needs only the built lib, so it runs on every build alongside the self_contained check.
+add_executable(consume_hecdss consume_hecdss.c)
+target_link_libraries(consume_hecdss hecdss)
+target_include_directories(consume_hecdss PRIVATE ${CMAKE_SOURCE_DIR}/heclib/hecdss)
+add_test(NAME consume_hecdss COMMAND consume_hecdss)
+
+# Windows: the test exe needs hecdss.dll discoverable at run time (mirrors the other tests).
+if(MSVC)
+    set_property(TEST consume_hecdss PROPERTY ENVIRONMENT_MODIFICATION
+        "PATH=path_list_append:$<TARGET_RUNTIME_DLL_DIRS:consume_hecdss>")
+endif()

--- a/test/consumer/consume_hecdss.c
+++ b/test/consumer/consume_hecdss.c
@@ -1,0 +1,23 @@
+/* Consume libhecdss exactly as an external user would: include only the public
+ * header (HECDSS_API resolves to dllimport / default visibility here, NOT dllexport)
+ * and call the exported C API. This exercises the shared-library export / import-lib /
+ * symbol-visibility and runtime-load path that the static-heclib tests never touch --
+ * i.e. it tests the artifact we actually ship, through its public boundary. */
+#include <stdio.h>
+#include "hecdss.h"
+
+int main(void) {
+    const char *v = hec_dss_api_version();
+    if (v == NULL) {
+        fprintf(stderr, "FAIL: hec_dss_api_version() returned NULL\n");
+        return 1;
+    }
+    printf("linked libhecdss; hec_dss_api_version() = %s\n", v);
+
+    /* A second exported symbol, to confirm more than one entry resolves. */
+    if (hec_dss_CONSTANT_MAX_PATH_SIZE() <= 0) {
+        fprintf(stderr, "FAIL: hec_dss_CONSTANT_MAX_PATH_SIZE() <= 0\n");
+        return 1;
+    }
+    return 0;
+}

--- a/test/jni/CMakeLists.txt
+++ b/test/jni/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Full JNI load test: compile a minimal hec.heclib.util.Heclib (matching the JNI symbol
+# naming) and run it on a real JVM that System.load()s the built javaHeclib and calls a
+# native method. This proves the published JNI native loads into a matching-arch JVM,
+# its dependencies resolve, and its exported JNI symbols bind -- i.e. the JNI artifact
+# works through the boundary a Java consumer actually uses.
+set(_jni_classes "${CMAKE_CURRENT_BINARY_DIR}/classes")
+
+add_custom_command(
+    OUTPUT "${_jni_classes}/hec/heclib/util/Heclib.class"
+    COMMAND "${Java_JAVAC_EXECUTABLE}" -d "${_jni_classes}" "${CMAKE_CURRENT_SOURCE_DIR}/Heclib.java"
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/Heclib.java"
+    COMMENT "Compiling JNI load-test harness"
+)
+add_custom_target(jni_loadtest_harness ALL
+    DEPENDS "${_jni_classes}/hec/heclib/util/Heclib.class")
+add_dependencies(jni_loadtest_harness javaHeclib)
+
+add_test(
+    NAME jni_load
+    COMMAND "${Java_JAVA_EXECUTABLE}" -cp "${_jni_classes}"
+            hec.heclib.util.Heclib "$<TARGET_FILE:javaHeclib>"
+)

--- a/test/jni/Heclib.java
+++ b/test/jni/Heclib.java
@@ -1,0 +1,26 @@
+package hec.heclib.util;
+
+/*
+ * Minimal stand-in for the real hec.heclib.util.Heclib: the class name and package
+ * must match the JNI symbol naming in javaHeclib (Java_hec_heclib_util_Heclib_*).
+ * We declare ONE native method so the test can load the published javaHeclib native
+ * and bind a JNI symbol -- proving the artifact loads into a matching-arch JVM, its
+ * dependencies resolve, and its exported JNI entry points are callable. This is the
+ * JNI equivalent of the consume_hecdss C-API smoke test.
+ */
+public class Heclib {
+    // Maps to Java_hec_heclib_util_Heclib_Hec_1zgetMessageLevel -- a side-effect-free
+    // getter that self-initializes, so it is safe to call without opening a DSS file.
+    public native int Hec_zgetMessageLevel(int group);
+
+    public static void main(String[] args) {
+        if (args.length < 1) {
+            System.err.println("usage: Heclib <absolute-path-to-javaHeclib-native>");
+            System.exit(2);
+        }
+        System.load(args[0]);                       // arch match + dependency resolution
+        int level = new Heclib().Hec_zgetMessageLevel(0);  // forces JNI symbol binding
+        System.out.println("JNI OK: loaded " + args[0] + "; Hec_zgetMessageLevel(0)=" + level);
+        // Any UnsatisfiedLinkError / exception above propagates and exits non-zero.
+    }
+}


### PR DESCRIPTION
**Stacked on #361** (`fix/static-zlib-and-self-contained-check`) — review/merge that first; this PR's diff is only the CI/packaging/test work on top of it.

Closes the loop so the published zip is the exact binary CI built, tested, and checked.

## Changes

**CI (`build-and-test.yml`)**
- Matrix keyed by published classifier: `linux-x86_64`, `win-x86_64`, `darwin-aarch64`, `darwin-x86_64` (cross-built on the arm64 runner via Rosetta, since GitHub no longer offers an Intel runner). Actions → v4, JDK → Temurin.
- Build and test the **Release** configuration (was Debug/default).
- CPack packages the native + header from the **same gated build** into a per-classifier artifact, instead of a separately produced zip. `zlib` gets `SKIP_INSTALL_ALL` so it isn't packaged alongside.

**API-boundary tests** (run on every build, need only the built lib)
- `consume_hecdss` — links the shared `hecdss` target and calls the exported C API, exercising the import-lib / symbol-visibility / runtime-load path.
- `jni_load` — runs a real JVM that `System.load()`s `javaHeclib` and calls a native method, proving the JNI artifact loads and binds in a matching-arch JVM.

## Known item

The `darwin-x86_64` job currently runs the full `ctest` suite — including the `Dss-C` functional test — under Rosetta. If that test proves emulation-sensitive, exclude it on that job (`ctest -E Dss-C`) rather than letting it gate the linkage/self-containment checks. Left as a follow-up pending observed CI behavior.